### PR TITLE
feat(inference-utils): port extract_json from lexbox

### DIFF
--- a/packages/inference/utils/bun.lock
+++ b/packages/inference/utils/bun.lock
@@ -1,0 +1,21 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@seed/inference-utils",
+      "devDependencies": {
+        "@types/bun": "latest",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+
+    "@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
+
+    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+  }
+}

--- a/packages/inference/utils/package.json
+++ b/packages/inference/utils/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@seed/inference-utils",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "test": "bun test",
+    "build": "tsc"
+  },
+  "devDependencies": {
+    "@types/bun": "latest"
+  },
+  "exports": {
+    ".": "./src/index.ts",
+    "./extract-json": "./src/extract-json.ts"
+  }
+}

--- a/packages/inference/utils/src/extract-json.test.ts
+++ b/packages/inference/utils/src/extract-json.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test";
+import { extractJson } from "./extract-json";
+
+describe("extractJson", () => {
+  test("clean JSON object", () => {
+    expect(extractJson('{"score": 7}')).toEqual({ score: 7 });
+  });
+
+  test("markdown fenced JSON", () => {
+    expect(extractJson('```json\n{"score": 7}\n```')).toEqual({ score: 7 });
+  });
+
+  test("thinking preamble before JSON", () => {
+    expect(extractJson('<think>blah blah</think>\n{"score": 7}')).toEqual({
+      score: 7,
+    });
+  });
+
+  test("text before and after JSON", () => {
+    const text =
+      'Here is my evaluation:\n{"score": 7, "issues": []}\nHope this helps!';
+    expect(extractJson(text)).toEqual({ score: 7, issues: [] });
+  });
+
+  test("nested braces", () => {
+    expect(extractJson('{"data": {"inner": 1}}')).toEqual({
+      data: { inner: 1 },
+    });
+  });
+
+  test("no JSON at all returns null", () => {
+    expect(extractJson("Just some text")).toBeNull();
+  });
+
+  test("partial/broken JSON returns null", () => {
+    expect(extractJson('{"score": 7,')).toBeNull();
+  });
+
+  test("multiple JSON objects returns first valid one", () => {
+    expect(extractJson('{"a": 1} and also {"b": 2}')).toEqual({ a: 1 });
+  });
+
+  test("JSON with newlines inside", () => {
+    expect(extractJson('{\n  "score": 7\n}')).toEqual({ score: 7 });
+  });
+
+  test("markdown fence with language tag and surrounding whitespace", () => {
+    const text = `
+        \`\`\`json
+        {
+            "score": 7
+        }
+        \`\`\`
+        `;
+    expect(extractJson(text)).toEqual({ score: 7 });
+  });
+
+  test("markdown fence without language tag", () => {
+    expect(extractJson('```\n{"score": 7}\n```')).toEqual({ score: 7 });
+  });
+
+  test("four-backtick fence variant", () => {
+    expect(extractJson('````json\n{"score": 7}\n````')).toEqual({ score: 7 });
+  });
+
+  test("empty string returns null", () => {
+    expect(extractJson("")).toBeNull();
+  });
+
+  test("JSON array", () => {
+    expect(extractJson("[1, 2, 3]")).toEqual([1, 2, 3]);
+  });
+
+  test("JSON with special characters", () => {
+    expect(extractJson('{"name": "John", "age": 30, "active": true}')).toEqual({
+      name: "John",
+      age: 30,
+      active: true,
+    });
+  });
+
+  test("JSON with unicode", () => {
+    expect(extractJson('{"emoji": "😀", "text": "Hello 世界"}')).toEqual({
+      emoji: "😀",
+      text: "Hello 世界",
+    });
+  });
+
+  test("JSON with mixed data types", () => {
+    const text =
+      '{"int": 42, "float": 3.14, "str": "hello", "bool": true, "null": null}';
+    expect(extractJson(text)).toEqual({
+      int: 42,
+      float: 3.14,
+      str: "hello",
+      bool: true,
+      null: null,
+    });
+  });
+
+  test("markdown fence with extra content inside", () => {
+    const text = '```json\nSome text\n{"score": 7}\nMore text\n```';
+    expect(extractJson(text)).toEqual({ score: 7 });
+  });
+
+  test("nested JSON objects in array", () => {
+    expect(extractJson('[{"a": 1}, {"b": 2}]')).toEqual([{ a: 1 }, { b: 2 }]);
+  });
+
+  test("JSON with escaped characters", () => {
+    const text = '{"text": "Hello\\nWorld", "quote": "He said \\"Hi\\""}';
+    expect(extractJson(text)).toEqual({
+      text: "Hello\nWorld",
+      quote: 'He said "Hi"',
+    });
+  });
+
+  test("complex nested structure", () => {
+    const text =
+      '{"user": {"name": "John", "profile": {"age": 30, "city": "NYC"}}}';
+    const result = extractJson(text);
+    expect(result).toEqual({
+      user: { name: "John", profile: { age: 30, city: "NYC" } },
+    });
+  });
+
+  test("braces inside strings don't throw off depth counting", () => {
+    // Braces inside the string should be ignored by the depth counter.
+    const result = extractJson('{"text": "has } and ] inside", "ok": true}');
+    expect(result).toEqual({
+      text: "has } and ] inside",
+      ok: true,
+    });
+  });
+});

--- a/packages/inference/utils/src/extract-json.ts
+++ b/packages/inference/utils/src/extract-json.ts
@@ -1,0 +1,74 @@
+/**
+ * Extract the first valid JSON object or array from messy LLM output.
+ *
+ * Handles several common failure modes:
+ *   - `<think>...</think>` reasoning preambles (stripped first)
+ *   - Markdown code fences (```json, ```, ````json, etc.) around the payload
+ *   - Prose before and after the JSON
+ *   - Nested objects and arrays (via string-aware brace counting)
+ *
+ * Returns `null` when no valid JSON can be extracted. Does not attempt to
+ * recover from a malformed first candidate — if the first balanced-brace
+ * window fails to parse, gives up. Ported from the Python implementation
+ * at existential/engine/lexbox/utils.py with the same semantics and tests.
+ */
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+export function extractJson(text: string): JsonValue | null {
+  if (!text) return null;
+
+  // Step 1: strip <think>...</think> tags (DOTALL).
+  let cleaned = text.replace(/<think>[\s\S]*?<\/think>/g, "");
+
+  // Step 2: strip markdown code fences, keep content inside.
+  //   matches ```, ````, etc. with optional `json`/`JSON` language tag
+  //   and optional trailing whitespace + newline.
+  cleaned = cleaned.replace(/`{3,}(?:json|JSON)?\s*\n?/g, "");
+
+  // Step 3: find the first { or [.
+  const startMatch = cleaned.search(/[{[]/);
+  if (startMatch === -1) return null;
+
+  // Step 4: brace-count to find the matching close, string-aware.
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+
+  for (let i = startMatch; i < cleaned.length; i++) {
+    const c = cleaned[i]!;
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (c === "\\" && inString) {
+      escape = true;
+      continue;
+    }
+    if (c === '"' && !escape) {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+    if (c === "{" || c === "[") {
+      depth++;
+    } else if (c === "}" || c === "]") {
+      depth--;
+      if (depth === 0) {
+        const candidate = cleaned.slice(startMatch, i + 1);
+        try {
+          return JSON.parse(candidate) as JsonValue;
+        } catch {
+          return null;
+        }
+      }
+    }
+  }
+
+  return null;
+}

--- a/packages/inference/utils/src/index.ts
+++ b/packages/inference/utils/src/index.ts
@@ -1,0 +1,1 @@
+export { extractJson, type JsonValue } from "./extract-json";

--- a/packages/inference/utils/tsconfig.json
+++ b/packages/inference/utils/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["bun"],
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

New `@seed/inference-utils` package with a robust JSON extractor for messy LLM output. Ported from `existential/engine/lexbox/utils.py:extract_json` with identical semantics.

Handles:
- `<think>…</think>` reasoning preambles (stripped first)
- Markdown code fences — 3+ backticks, optional `json`/`JSON` language tag
- Prose before and after the JSON payload
- Nested objects and arrays via string-aware brace counting
- Braces and brackets inside string literals (ignored by the depth counter)

Returns `null` when the first balanced-brace candidate fails to parse — same single-attempt behavior as the Python. Output typed as `JsonValue | null`.

## What's in the package

- `src/extract-json.ts` — the extractor + `JsonValue` type
- `src/extract-json.test.ts` — 22 tests (all 21 Python cases + braces-in-strings)
- `src/index.ts` — re-exports
- `package.json`, `tsconfig.json` — matches existing `packages/inference/*` conventions

## Why

Phase 1 PR #2 of the LexBox → Seed extraction (see \`existential/handoff/lexbox-to-seed-extraction.md\`). Anywhere Seed asks a local model for structured output, it needs this utility — router dispatch, memory ingest summarization, future sensitivity classification, grading primitives. LexBox documented 2/7 grading runs dropped without it.

## Test plan

- [x] \`bun test\` — 22 pass, 0 fail
- [x] \`bunx tsc --noEmit\` — clean
- [ ] Follow-up: wire this into \`packages/memory/src/summarize.ts\` and router dispatch paths