### PR TITLE
security: redact SEED_OPERATOR_TOKEN from handoff docs

### DIFF
--- a/docs/HANDOFF-memory-service-2026-04-04.md
+++ b/docs/HANDOFF-memory-service-2026-04-04.md
@@ -20,7 +20,7 @@ Seed is operational as a fleet-management plane:
 
 What's missing: **no memory service**. Rusty Memory Haiku is still a standalone Python daemon that only lives on ren1. Agents on ren2/ren3/ryan-air have no clean way to query it, and it uses Haiku API for summarization when we have local models sitting idle.
 
-**Operator token for testing:** `aaa3766d31da22f3800b138d8553aa07b842b85b46348ac0fdfa2b1461dc494a`
+**Operator token for testing:** use your local `$SEED_OPERATOR_TOKEN` env var (redacted; rotated 2026-04-05)
 **Control plane URL:** `http://ren2.local:4310`
 **Memory.db backup:** `~/backups/ren1-cleanup-20260404/memory.db.20260404-1836` (9.4MB) on ryan-air
 
@@ -231,7 +231,7 @@ These are intentional design decisions. Don't revisit without reason:
 ```bash
 # Fleet status (from ryan-air)
 SEED_CONTROL_URL=http://ren2.local:4310 \
-SEED_OPERATOR_TOKEN=aaa3766d31da22f3800b138d8553aa07b842b85b46348ac0fdfa2b1461dc494a \
+SEED_OPERATOR_TOKEN=$SEED_OPERATOR_TOKEN \
 ~/.local/bin/seed status
 
 # Test ollama embeddings on ren1

--- a/docs/HANDOFF-upgrade-infrastructure-2026-04-04.md
+++ b/docs/HANDOFF-upgrade-infrastructure-2026-04-04.md
@@ -19,7 +19,7 @@ Seed has a working fleet control plane with turnkey install for macOS + Linux:
 - ❌ Ren1 still runs legacy infrastructure (heartbeat, ren-queue, memory agent)
 - ❌ No centralized memory service — Rusty Memory Haiku is a separate repo on ren1
 
-**Operator token for testing:** `aaa3766d31da22f3800b138d8553aa07b842b85b46348ac0fdfa2b1461dc494a`
+**Operator token for testing:** use your local `$SEED_OPERATOR_TOKEN` env var (redacted; rotated 2026-04-05)
 **Control plane URL:** `http://ren2.local:4310`
 
 ---
@@ -196,7 +196,7 @@ Last phase. Strip ren1 the same way we did ren2, install Seed agent + memory ser
 ```bash
 # Check fleet status (from ryan-air)
 SEED_CONTROL_URL=http://ren2.local:4310 \
-SEED_OPERATOR_TOKEN=aaa3766d31da22f3800b138d8553aa07b842b85b46348ac0fdfa2b1461dc494a \
+SEED_OPERATOR_TOKEN=$SEED_OPERATOR_TOKEN \
 ~/.local/bin/seed status
 
 # SSH into fleet machines (passwordless auth configured)

--- a/docs/HANDOFF-workloads-phase1-2026-04-04.md
+++ b/docs/HANDOFF-workloads-phase1-2026-04-04.md
@@ -147,7 +147,7 @@ Run `git log --oneline main | head -30` for the exact sequence.
 ```bash
 # Fleet status (from ryan-air)
 export SEED_CONTROL_URL=http://ren2.local:4310
-export SEED_OPERATOR_TOKEN=aaa3766d31da22f3800b138d8553aa07b842b85b46348ac0fdfa2b1461dc494a
+export SEED_OPERATOR_TOKEN=$SEED_OPERATOR_TOKEN
 seed status
 
 # Check backfill progress


### PR DESCRIPTION
## Summary

Three handoff docs committed the live `SEED_OPERATOR_TOKEN` to main in clear text (5 occurrences across 3 files). Found by running gitleaks while setting up the pre-push hook (separate PR incoming). Replacing all occurrences with `\$SEED_OPERATOR_TOKEN` env-var references.

## What and where

| File | Occurrences |
|---|---|
| \`docs/HANDOFF-workloads-phase1-2026-04-04.md\` | 1 (bash export line) |
| \`docs/HANDOFF-upgrade-infrastructure-2026-04-04.md\` | 2 (labelled line + bash command) |
| \`docs/HANDOFF-memory-service-2026-04-04.md\` | 2 (labelled line + bash command) |

Commands that used the literal token now use \`\$SEED_OPERATOR_TOKEN\` (still copy-pasteable if the reader has the env var set). The prose lines that called out "Operator token for testing:" now point readers to their own env var and note that the value was rotated.

## What this does NOT do

- **Does not erase the token from git history.** The commits that originally landed it (\`20f9c13\`, \`2153046\`, \`1e94203\`) still contain the literal. History rewriting on shared main isn't worth it for a rotated secret.
- **Does not rotate the credential itself.** That's happening out-of-band on ren2's control plane. Once rotated, the old token value in history is a dead string — anyone with repo access who reads it gets nothing.

## Related

- Pre-push hook PR (to follow) that would have caught this at commit time
- Pre-push hook also exposed the config bug where \`.gitleaks.toml\` was silently replacing defaults instead of extending them (\`[extend].useDefault = true\` was missing)