### PR TITLE
feat(jury): @seed/jury provider-agnostic jury primitive

### DIFF
--- a/packages/inference/jury/bun.lock
+++ b/packages/inference/jury/bun.lock
@@ -1,0 +1,21 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@seed/jury",
+      "devDependencies": {
+        "@types/bun": "latest",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+
+    "@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
+
+    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+  }
+}

--- a/packages/inference/jury/package.json
+++ b/packages/inference/jury/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@seed/jury",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "bunx tsc --noEmit",
+    "build": "tsc"
+  },
+  "devDependencies": {
+    "@types/bun": "latest"
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/packages/inference/jury/src/agreement.test.ts
+++ b/packages/inference/jury/src/agreement.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { calculateAgreement } from "./agreement";
+
+describe("calculateAgreement", () => {
+  test("returns 1 for zero responses", () => {
+    expect(calculateAgreement([])).toBe(1);
+  });
+
+  test("returns 1 for single response", () => {
+    expect(calculateAgreement(["the quick brown fox"])).toBe(1);
+  });
+
+  test("returns 1 for identical responses", () => {
+    expect(calculateAgreement(["hello world again", "hello world again"])).toBe(1);
+  });
+
+  test("returns 0 for fully disjoint responses", () => {
+    const a = "alpha beta gamma delta";
+    const b = "epsilon zeta theta iota";
+    expect(calculateAgreement([a, b])).toBe(0);
+  });
+
+  test("returns partial overlap for half-shared vocabulary", () => {
+    const a = "alpha beta gamma delta";
+    const b = "alpha beta zeta theta";
+    // 2 shared / 6 union = 0.33
+    expect(calculateAgreement([a, b])).toBeGreaterThan(0.2);
+    expect(calculateAgreement([a, b])).toBeLessThan(0.5);
+  });
+
+  test("ignores words of length <= 3", () => {
+    // Short words are filtered, so "to be or not" drops everything.
+    const a = "to be or not";
+    const b = "this that them then";
+    expect(calculateAgreement([a, b])).toBe(0);
+  });
+
+  test("is case-insensitive", () => {
+    const upper = "HELLO WORLD AGAIN";
+    const lower = "hello world again";
+    expect(calculateAgreement([upper, lower])).toBe(1);
+  });
+
+  test("averages across pairs for 3+ responses", () => {
+    const a = "alpha beta gamma";
+    const b = "alpha beta delta";
+    const c = "alpha beta epsilon";
+    // Every pair shares {alpha,beta} out of a 4-word union → 0.5
+    expect(calculateAgreement([a, b, c])).toBe(0.5);
+  });
+});

--- a/packages/inference/jury/src/agreement.ts
+++ b/packages/inference/jury/src/agreement.ts
@@ -1,0 +1,34 @@
+// Compute lexical Jaccard-overlap agreement across juror responses.
+//
+// Not a semantic measure — just a cheap signal of whether the jurors are
+// saying vaguely the same thing. Low agreement is a hint to the caller
+// that synthesis is doing real work; high agreement means the jurors
+// converged on their own.
+
+export function calculateAgreement(responses: string[]): number {
+  if (responses.length <= 1) return 1;
+
+  const wordSets = responses.map((r) =>
+    new Set(
+      r
+        .toLowerCase()
+        .split(/\s+/)
+        .filter((w) => w.length > 3),
+    ),
+  );
+
+  let totalOverlap = 0;
+  let pairs = 0;
+  for (let i = 0; i < wordSets.length; i++) {
+    for (let j = i + 1; j < wordSets.length; j++) {
+      const a = wordSets[i];
+      const b = wordSets[j];
+      const intersection = new Set([...a].filter((w) => b.has(w)));
+      const union = new Set([...a, ...b]);
+      totalOverlap += union.size > 0 ? intersection.size / union.size : 0;
+      pairs++;
+    }
+  }
+
+  return pairs > 0 ? Math.round((totalOverlap / pairs) * 100) / 100 : 1;
+}

--- a/packages/inference/jury/src/default-aggregator.test.ts
+++ b/packages/inference/jury/src/default-aggregator.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+import { makeDefaultAggregator } from "./default-aggregator";
+import type { ChatMessage, InvokeResult, JurorResult } from "./types";
+
+function juror(id: string, content: string, error: string | null = null): JurorResult {
+  return {
+    id,
+    content,
+    error,
+    durationMs: 10,
+    tokensPerSecond: 50,
+  };
+}
+
+describe("makeDefaultAggregator", () => {
+  test("short-circuits to single juror when only one is valid", async () => {
+    let invoked = false;
+    const invoke = async (): Promise<InvokeResult> => {
+      invoked = true;
+      return { content: "should not be called" };
+    };
+    const aggregator = makeDefaultAggregator({ invoke });
+    const result = await aggregator({
+      question: "q",
+      jurors: [juror("a", "alpha"), juror("b", "", "timeout")],
+      maxTokens: 256,
+    });
+    expect(result).toBe("alpha");
+    expect(invoked).toBe(false);
+  });
+
+  test("throws when all jurors failed", async () => {
+    const invoke = async (): Promise<InvokeResult> => ({ content: "" });
+    const aggregator = makeDefaultAggregator({ invoke });
+    await expect(
+      aggregator({
+        question: "q",
+        jurors: [juror("a", "", "err"), juror("b", "", "err")],
+        maxTokens: 256,
+      }),
+    ).rejects.toThrow("All jurors failed");
+  });
+
+  test("synthesizes when multiple jurors valid", async () => {
+    let captured: { messages: ChatMessage[]; temperature: number; maxTokens: number } | null = null;
+    const invoke = async (
+      messages: ChatMessage[],
+      opts: { temperature: number; maxTokens: number },
+    ): Promise<InvokeResult> => {
+      captured = { messages, temperature: opts.temperature, maxTokens: opts.maxTokens };
+      return { content: "synthesized answer" };
+    };
+    const aggregator = makeDefaultAggregator({ invoke });
+    const result = await aggregator({
+      question: "what is the capital of france?",
+      jurors: [juror("a", "Paris."), juror("b", "The capital is Paris.")],
+      maxTokens: 256,
+    });
+    expect(result).toBe("synthesized answer");
+    expect(captured).not.toBeNull();
+    expect(captured!.temperature).toBe(0.3);
+    expect(captured!.maxTokens).toBe(256);
+    const userPrompt = captured!.messages.find((m) => m.role === "user")!.content;
+    expect(userPrompt).toContain("what is the capital of france?");
+    expect(userPrompt).toContain("Paris.");
+    expect(userPrompt).toContain("The capital is Paris.");
+    expect(userPrompt).toContain("Juror 1");
+    expect(userPrompt).toContain("Juror 2");
+  });
+
+  test("honors custom temperature", async () => {
+    let captured = 0;
+    const invoke = async (_m: ChatMessage[], opts: { temperature: number; maxTokens: number }) => {
+      captured = opts.temperature;
+      return { content: "x" };
+    };
+    const aggregator = makeDefaultAggregator({ invoke, temperature: 0.9 });
+    await aggregator({
+      question: "q",
+      jurors: [juror("a", "one"), juror("b", "two")],
+      maxTokens: 100,
+    });
+    expect(captured).toBe(0.9);
+  });
+
+  test("prepends custom system prompt when provided", async () => {
+    let messages: ChatMessage[] = [];
+    const invoke = async (m: ChatMessage[]) => {
+      messages = m;
+      return { content: "x" };
+    };
+    const aggregator = makeDefaultAggregator({ invoke, systemPrompt: "be a pirate" });
+    await aggregator({
+      question: "q",
+      jurors: [juror("a", "one"), juror("b", "two")],
+      maxTokens: 100,
+    });
+    expect(messages[0]).toEqual({ role: "system", content: "be a pirate" });
+    expect(messages).toHaveLength(2);
+  });
+
+  test("includes juror role in prompt label when provided", async () => {
+    let captured = "";
+    const invoke = async (m: ChatMessage[]) => {
+      captured = m.find((x) => x.role === "user")!.content;
+      return { content: "x" };
+    };
+    const aggregator = makeDefaultAggregator({ invoke });
+    const jRoles: JurorResult[] = [
+      { ...juror("gemma4:e2b@ren1", "a"), role: "fast-reviewer" },
+      { ...juror("gemma4:e4b@ren2", "b"), role: "quality-reviewer" },
+    ];
+    await aggregator({ question: "q", jurors: jRoles, maxTokens: 100 });
+    expect(captured).toContain("fast-reviewer — gemma4:e2b@ren1");
+    expect(captured).toContain("quality-reviewer — gemma4:e4b@ren2");
+  });
+});

--- a/packages/inference/jury/src/default-aggregator.ts
+++ b/packages/inference/jury/src/default-aggregator.ts
@@ -1,0 +1,58 @@
+// Default aggregator prompt builder. Consumers wrap a model invocation
+// around this to produce a consensus string.
+//
+// The prompt pattern is lifted from the existing fleet-router jury: the
+// aggregator is told to take the strongest elements from each juror and
+// not mention the synthesis process. That framing reliably produces
+// single-voice output instead of "Juror 1 said X, but Juror 2 said Y"
+// summaries.
+
+import type { AggregatorFn, ChatMessage, InvokeResult, JurorResult } from "./types";
+
+export interface DefaultAggregatorOptions {
+  /** Invocation fn bound to the aggregator model (typically a higher-tier model). */
+  invoke: (messages: ChatMessage[], options: { temperature: number; maxTokens: number }) => Promise<InvokeResult>;
+  /** Optional override for the system framing. */
+  systemPrompt?: string;
+  /** Aggregator temperature. Default: 0.3 (deterministic synthesis). */
+  temperature?: number;
+}
+
+/**
+ * Build an AggregatorFn that synthesizes juror responses via the given
+ * invoke function. Skips aggregation if only one juror produced
+ * content — returns that content directly.
+ */
+export function makeDefaultAggregator(options: DefaultAggregatorOptions): AggregatorFn {
+  const temperature = options.temperature ?? 0.3;
+
+  return async function defaultAggregator({ question, jurors, maxTokens }) {
+    const valid = jurors.filter((j) => !j.error && j.content.length > 0);
+    if (valid.length === 0) throw new Error("All jurors failed");
+    if (valid.length === 1) return valid[0].content;
+
+    const responsesText = valid.map((j, i) => formatJuror(j, i)).join("\n\n");
+
+    const aggregationPrompt = `You are synthesizing ${valid.length} model responses into one best answer. Be concise and direct.
+
+Question: ${question}
+
+Responses:
+${responsesText}
+
+Synthesize into a single best response. Take the strongest elements from each. Do not mention the jurors or the synthesis process.`;
+
+    const systemPrompt = options.systemPrompt;
+    const messages: ChatMessage[] = [];
+    if (systemPrompt) messages.push({ role: "system", content: systemPrompt });
+    messages.push({ role: "user", content: aggregationPrompt });
+
+    const result = await options.invoke(messages, { temperature, maxTokens });
+    return result.content;
+  };
+}
+
+function formatJuror(juror: JurorResult, index: number): string {
+  const label = juror.role ? `${juror.role} — ${juror.id}` : juror.id;
+  return `[Juror ${index + 1} (${label})]:\n${juror.content}`;
+}

--- a/packages/inference/jury/src/index.ts
+++ b/packages/inference/jury/src/index.ts
@@ -1,0 +1,15 @@
+export { runJury } from "./jury";
+export { calculateAgreement } from "./agreement";
+export { makeDefaultAggregator } from "./default-aggregator";
+export type { DefaultAggregatorOptions } from "./default-aggregator";
+export type {
+  AggregatorContext,
+  AggregatorFn,
+  ChatMessage,
+  InvokeOptions,
+  InvokeResult,
+  JurorAssignment,
+  JurorResult,
+  JuryRequest,
+  JuryResponse,
+} from "./types";

--- a/packages/inference/jury/src/jury.test.ts
+++ b/packages/inference/jury/src/jury.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, test } from "bun:test";
+import { runJury } from "./jury";
+import type {
+  AggregatorFn,
+  ChatMessage,
+  InvokeResult,
+  JurorAssignment,
+  JurorResult,
+  JuryRequest,
+} from "./types";
+
+function ok(content: string, completionTokens = 10): InvokeResult {
+  return { content, promptTokens: 5, completionTokens };
+}
+
+function juror(id: string, result: InvokeResult | Error, delayMs = 0): JurorAssignment {
+  return {
+    id,
+    role: `juror-${id}`,
+    invoke: async () => {
+      if (delayMs > 0) await new Promise((r) => setTimeout(r, delayMs));
+      if (result instanceof Error) throw result;
+      return result;
+    },
+  };
+}
+
+const passThroughAggregator: AggregatorFn = async ({ jurors }) => {
+  const valid = jurors.filter((j) => !j.error && j.content.length > 0);
+  if (valid.length === 0) throw new Error("All jurors failed");
+  return `consensus(${valid.map((j) => j.content).join("|")})`;
+};
+
+const baseMessages: ChatMessage[] = [
+  { role: "system", content: "be terse" },
+  { role: "user", content: "what is the capital of france?" },
+];
+
+describe("runJury", () => {
+  test("fans out to all jurors and aggregates", async () => {
+    const req: JuryRequest = {
+      messages: baseMessages,
+      jurors: [juror("a", ok("paris")), juror("b", ok("paris.")), juror("c", ok("PARIS"))],
+      aggregator: passThroughAggregator,
+    };
+    const res = await runJury(req);
+    expect(res.consensus).toBe("consensus(paris|paris.|PARIS)");
+    expect(res.jurors).toHaveLength(3);
+    expect(res.jurors.every((j) => j.error === null)).toBe(true);
+    expect(res.agreement).toBeGreaterThan(0);
+  });
+
+  test("captures juror errors without failing the run", async () => {
+    const req: JuryRequest = {
+      messages: baseMessages,
+      jurors: [juror("a", ok("paris")), juror("b", new Error("timeout"))],
+      aggregator: passThroughAggregator,
+    };
+    const res = await runJury(req);
+    expect(res.jurors[0].error).toBeNull();
+    expect(res.jurors[1].error).toBe("timeout");
+    expect(res.jurors[1].content).toBe("");
+    expect(res.consensus).toBe("consensus(paris)");
+  });
+
+  test("throws if all jurors fail and aggregator signals", async () => {
+    const req: JuryRequest = {
+      messages: baseMessages,
+      jurors: [juror("a", new Error("boom")), juror("b", new Error("boom"))],
+      aggregator: passThroughAggregator,
+    };
+    await expect(runJury(req)).rejects.toThrow("All jurors failed");
+  });
+
+  test("throws if jurors array is empty", async () => {
+    const req: JuryRequest = {
+      messages: baseMessages,
+      jurors: [],
+      aggregator: passThroughAggregator,
+    };
+    await expect(runJury(req)).rejects.toThrow(/empty/);
+  });
+
+  test("honors explicit temperature override on juror", async () => {
+    const temps: number[] = [];
+    const j: JurorAssignment = {
+      id: "temp-check",
+      temperature: 0.77,
+      invoke: async (_msgs, opts) => {
+        temps.push(opts.temperature);
+        return ok("x");
+      },
+    };
+    await runJury({
+      messages: baseMessages,
+      jurors: [j],
+      aggregator: passThroughAggregator,
+    });
+    expect(temps).toEqual([0.77]);
+  });
+
+  test("assigns default temperature cycle when jurors don't specify", async () => {
+    const temps: number[] = [];
+    const makeJ = (id: string): JurorAssignment => ({
+      id,
+      invoke: async (_msgs, opts) => {
+        temps.push(opts.temperature);
+        return ok("x");
+      },
+    });
+    await runJury({
+      messages: baseMessages,
+      jurors: [makeJ("a"), makeJ("b"), makeJ("c"), makeJ("d"), makeJ("e")],
+      aggregator: passThroughAggregator,
+    });
+    expect(temps).toEqual([0.3, 0.5, 0.7, 0.9, 0.3]);
+  });
+
+  test("passes maxTokens from request through to invoke", async () => {
+    let capturedMax = 0;
+    const j: JurorAssignment = {
+      id: "max-check",
+      invoke: async (_msgs, opts) => {
+        capturedMax = opts.maxTokens;
+        return ok("x");
+      },
+    };
+    await runJury({
+      messages: baseMessages,
+      jurors: [j],
+      aggregator: passThroughAggregator,
+      maxTokens: 1024,
+    });
+    expect(capturedMax).toBe(1024);
+  });
+
+  test("defaults maxTokens to 512 when not specified", async () => {
+    let capturedMax = 0;
+    const j: JurorAssignment = {
+      id: "max-check",
+      invoke: async (_msgs, opts) => {
+        capturedMax = opts.maxTokens;
+        return ok("x");
+      },
+    };
+    await runJury({
+      messages: baseMessages,
+      jurors: [j],
+      aggregator: passThroughAggregator,
+    });
+    expect(capturedMax).toBe(512);
+  });
+
+  test("calls onJurorComplete for success and error", async () => {
+    const completions: JurorResult[] = [];
+    const req: JuryRequest = {
+      messages: baseMessages,
+      jurors: [juror("a", ok("paris")), juror("b", new Error("boom"))],
+      aggregator: passThroughAggregator,
+      onJurorComplete: (r) => completions.push(r),
+    };
+    await runJury(req);
+    expect(completions).toHaveLength(2);
+    const byId = Object.fromEntries(completions.map((c) => [c.id, c]));
+    expect(byId.a.error).toBeNull();
+    expect(byId.b.error).toBe("boom");
+  });
+
+  test("calls onAggregateComplete with success status", async () => {
+    let info: { durationMs: number; status: string } | null = null;
+    const req: JuryRequest = {
+      messages: baseMessages,
+      jurors: [juror("a", ok("paris"))],
+      aggregator: passThroughAggregator,
+      onAggregateComplete: (i) => {
+        info = i;
+      },
+    };
+    await runJury(req);
+    expect(info).not.toBeNull();
+    expect(info!.status).toBe("success");
+    expect(info!.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  test("calls onAggregateComplete with error status when aggregator throws", async () => {
+    let info: { status: string; error?: string } | null = null;
+    const failingAggregator: AggregatorFn = async () => {
+      throw new Error("aggregator down");
+    };
+    const req: JuryRequest = {
+      messages: baseMessages,
+      jurors: [juror("a", ok("paris"))],
+      aggregator: failingAggregator,
+      onAggregateComplete: (i) => {
+        info = i;
+      },
+    };
+    await expect(runJury(req)).rejects.toThrow("aggregator down");
+    expect(info).not.toBeNull();
+    expect(info!.status).toBe("error");
+    expect(info!.error).toBe("aggregator down");
+  });
+
+  test("uses custom queue hook for each juror", async () => {
+    const calls: string[] = [];
+    const queue = async <T>(id: string, task: () => Promise<T>): Promise<T> => {
+      calls.push(id);
+      return task();
+    };
+    await runJury({
+      messages: baseMessages,
+      jurors: [juror("a", ok("x")), juror("b", ok("y"))],
+      aggregator: passThroughAggregator,
+      queue,
+    });
+    expect(calls.sort()).toEqual(["a", "b"]);
+  });
+
+  test("computes tokensPerSecond from completionTokens + duration", async () => {
+    const j: JurorAssignment = {
+      id: "slow",
+      invoke: async () => {
+        await new Promise((r) => setTimeout(r, 50));
+        return { content: "ok", completionTokens: 100 };
+      },
+    };
+    const res = await runJury({
+      messages: baseMessages,
+      jurors: [j],
+      aggregator: passThroughAggregator,
+    });
+    expect(res.jurors[0].tokensPerSecond).toBeGreaterThan(0);
+  });
+
+  test("passes last user message as question to aggregator", async () => {
+    let capturedQuestion = "";
+    const ag: AggregatorFn = async ({ question }) => {
+      capturedQuestion = question;
+      return "ok";
+    };
+    await runJury({
+      messages: [
+        { role: "system", content: "sys" },
+        { role: "user", content: "first" },
+        { role: "assistant", content: "a" },
+        { role: "user", content: "second" },
+      ],
+      jurors: [juror("a", ok("x"))],
+      aggregator: ag,
+    });
+    expect(capturedQuestion).toBe("second");
+  });
+
+  test("single juror success is aggregated normally", async () => {
+    const res = await runJury({
+      messages: baseMessages,
+      jurors: [juror("solo", ok("the only answer"))],
+      aggregator: passThroughAggregator,
+    });
+    expect(res.consensus).toBe("consensus(the only answer)");
+    expect(res.jurors).toHaveLength(1);
+    expect(res.agreement).toBe(1);
+  });
+
+  test("fans out concurrently (total time ≈ slowest juror)", async () => {
+    const start = Date.now();
+    const res = await runJury({
+      messages: baseMessages,
+      jurors: [
+        juror("a", ok("x"), 60),
+        juror("b", ok("y"), 60),
+        juror("c", ok("z"), 60),
+      ],
+      aggregator: passThroughAggregator,
+    });
+    const elapsed = Date.now() - start;
+    // Sequential would be ≥180ms. Concurrent should be under 150ms
+    // with generous headroom for CI jitter.
+    expect(elapsed).toBeLessThan(150);
+    expect(res.jurors).toHaveLength(3);
+  });
+});

--- a/packages/inference/jury/src/jury.ts
+++ b/packages/inference/jury/src/jury.ts
@@ -1,0 +1,119 @@
+// runJury — fan out to jurors concurrently, aggregate into consensus.
+//
+// Temperature defaults (0.3/0.5/0.7/0.9) come from the battle-tested
+// fleet-router jury and give the jurors enough sampler diversity that
+// their outputs differ meaningfully even when they share a base model.
+
+import { calculateAgreement } from "./agreement";
+import type {
+  InvokeOptions,
+  JurorAssignment,
+  JurorResult,
+  JuryRequest,
+  JuryResponse,
+} from "./types";
+
+const DEFAULT_TEMPERATURES = [0.3, 0.5, 0.7, 0.9];
+const DEFAULT_MAX_TOKENS = 512;
+
+export async function runJury(request: JuryRequest): Promise<JuryResponse> {
+  const { jurors, messages, aggregator, queue, onJurorComplete, onAggregateComplete } = request;
+
+  if (jurors.length === 0) {
+    throw new Error("runJury: jurors[] is empty");
+  }
+
+  const maxTokens = request.maxTokens ?? DEFAULT_MAX_TOKENS;
+  const start = Date.now();
+  const lastUserMsg = lastUserContent(messages);
+
+  const jurorResults = await Promise.all(
+    jurors.map((juror, index) => {
+      const options: InvokeOptions = {
+        temperature: juror.temperature ?? DEFAULT_TEMPERATURES[index % DEFAULT_TEMPERATURES.length],
+        maxTokens,
+      };
+      const task = () => invokeOne(juror, messages, options, onJurorComplete);
+      return queue ? queue(juror.id, task) : task();
+    }),
+  );
+
+  const aggregateStart = Date.now();
+  let consensus: string;
+  try {
+    consensus = await aggregator({ question: lastUserMsg, jurors: jurorResults, maxTokens });
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    onAggregateComplete?.({
+      durationMs: Date.now() - aggregateStart,
+      status: "error",
+      error: errMsg,
+    });
+    throw err;
+  }
+
+  const aggregateDurationMs = Date.now() - aggregateStart;
+  onAggregateComplete?.({ durationMs: aggregateDurationMs, status: "success" });
+
+  const validContents = jurorResults
+    .filter((r) => !r.error && r.content.length > 0)
+    .map((r) => r.content);
+  const agreement = calculateAgreement(validContents);
+
+  return {
+    consensus,
+    jurors: jurorResults,
+    agreement,
+    aggregateDurationMs,
+    totalDurationMs: Date.now() - start,
+  };
+}
+
+async function invokeOne(
+  juror: JurorAssignment,
+  messages: JuryRequest["messages"],
+  options: InvokeOptions,
+  onComplete: JuryRequest["onJurorComplete"],
+): Promise<JurorResult> {
+  const taskStart = Date.now();
+  try {
+    const res = await juror.invoke(messages, options);
+    const durationMs = Date.now() - taskStart;
+    const seconds = durationMs / 1000;
+    const tokensPerSecond =
+      res.completionTokens && seconds > 0
+        ? Math.round((res.completionTokens / seconds) * 10) / 10
+        : 0;
+    const result: JurorResult = {
+      id: juror.id,
+      role: juror.role,
+      content: res.content,
+      durationMs,
+      promptTokens: res.promptTokens,
+      completionTokens: res.completionTokens,
+      tokensPerSecond,
+      error: null,
+    };
+    onComplete?.(result);
+    return result;
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    const result: JurorResult = {
+      id: juror.id,
+      role: juror.role,
+      content: "",
+      durationMs: Date.now() - taskStart,
+      tokensPerSecond: 0,
+      error: errMsg,
+    };
+    onComplete?.(result);
+    return result;
+  }
+}
+
+function lastUserContent(messages: JuryRequest["messages"]): string {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === "user") return messages[i].content;
+  }
+  return messages[messages.length - 1]?.content ?? "";
+}

--- a/packages/inference/jury/src/types.ts
+++ b/packages/inference/jury/src/types.ts
@@ -1,0 +1,85 @@
+// @seed/jury — provider-agnostic jury primitive.
+//
+// The jury pattern fans a query out to multiple models concurrently, then
+// aggregates the juror outputs into a single consensus response. This
+// package intentionally knows nothing about providers, machines, or
+// transport — callers supply `invoke` functions that wrap whichever
+// backend (local Ollama, MLX, cloud) they want to use.
+
+export interface ChatMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+}
+
+export interface InvokeOptions {
+  temperature: number;
+  maxTokens: number;
+}
+
+export interface InvokeResult {
+  content: string;
+  promptTokens?: number;
+  completionTokens?: number;
+}
+
+/**
+ * A single juror assignment. The caller is responsible for binding the
+ * invoke function to a specific provider + model + host + auth. The
+ * jury primitive only ever calls `invoke(messages, options)`.
+ */
+export interface JurorAssignment {
+  /** Human-readable identifier, e.g. "gemma4:e4b@ren2". Used in telemetry + aggregator prompts. */
+  id: string;
+  /** Optional descriptive role for the juror (used in aggregator prompt if present). */
+  role?: string;
+  /** Sampler temperature for this juror. Defaults vary by fleet position. */
+  temperature?: number;
+  /** Bound invocation function. Called once per jury run. */
+  invoke: (messages: ChatMessage[], options: InvokeOptions) => Promise<InvokeResult>;
+}
+
+export interface JurorResult {
+  id: string;
+  role?: string;
+  content: string;
+  durationMs: number;
+  promptTokens?: number;
+  completionTokens?: number;
+  tokensPerSecond: number;
+  error: string | null;
+}
+
+export interface AggregatorContext {
+  question: string;
+  jurors: JurorResult[];
+  maxTokens: number;
+}
+
+/**
+ * Aggregator synthesizes juror outputs into a single consensus response.
+ * Caller supplies this — typically wraps a higher-tier model (MLX
+ * Qwen3.5-9B in the local fleet, a frontier model for cloud use).
+ */
+export type AggregatorFn = (ctx: AggregatorContext) => Promise<string>;
+
+export interface JuryRequest {
+  messages: ChatMessage[];
+  jurors: JurorAssignment[];
+  aggregator: AggregatorFn;
+  /** Max tokens passed to each juror and the aggregator. Default: 512. */
+  maxTokens?: number;
+  /** Optional per-juror queue (e.g. machine-level concurrency limit). */
+  queue?: <T>(id: string, task: () => Promise<T>) => Promise<T>;
+  /** Telemetry hook fired once per juror completion (success or error). */
+  onJurorComplete?: (result: JurorResult) => void;
+  /** Telemetry hook fired once after aggregation completes. */
+  onAggregateComplete?: (info: { durationMs: number; status: "success" | "error"; error?: string }) => void;
+}
+
+export interface JuryResponse {
+  consensus: string;
+  jurors: JurorResult[];
+  agreement: number;
+  aggregateDurationMs: number;
+  totalDurationMs: number;
+}

--- a/packages/inference/jury/tsconfig.json
+++ b/packages/inference/jury/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["bun"],
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- New package \`@seed/jury\` at \`packages/inference/jury/\`.
- \`runJury()\` fans out to \`JurorAssignment\`s concurrently and calls a caller-supplied \`AggregatorFn\` to produce consensus.
- Provider-agnostic: callers bind \`invoke(messages, options)\` to any backend (local MLX/Ollama, or cloud once Arc C lands).
- \`makeDefaultAggregator()\` wraps an invoke fn in the fleet-router synthesis prompt and short-circuits to the single-juror case when only one juror produced content.
- \`calculateAgreement()\` lexical Jaccard overlap as a diagnostic signal.
- Telemetry hooks (\`onJurorComplete\`, \`onAggregateComplete\`) + optional per-juror \`queue\` hook.
- Default temperature cycle \`[0.3, 0.5, 0.7, 0.9]\` matches the battle-tested fleet-router jury.

## Context
First of three arcs:
- **A (this PR):** extract jury as a reusable primitive
- **C (next):** real runtime for cloud provider adapters (cerebras/groq/openrouter/gemini/anthropic/openai)
- **B (after C):** challenge round with tiered escalation (local → midtier → frontier), sensitivity-gated

Does **not** touch \`packages/inference/router/src/router.ts\` — the deployed fleet-router keeps its inline jury until a future follow-up reconciles them.

## Test plan
- [x] \`bun test\` — 30 tests pass
- [x] \`bunx tsc --noEmit\` — clean
- [x] gitleaks clean on push