### PR TITLE
feat(jury): challenge round with tiered escalation

### DIFF
--- a/packages/inference/jury/bun.lock
+++ b/packages/inference/jury/bun.lock
@@ -4,12 +4,17 @@
   "workspaces": {
     "": {
       "name": "@seed/jury",
+      "dependencies": {
+        "@seed/inference-utils": "file:../utils",
+      },
       "devDependencies": {
         "@types/bun": "latest",
       },
     },
   },
   "packages": {
+    "@seed/inference-utils": ["@seed/inference-utils@file:../utils", { "devDependencies": { "@types/bun": "latest" } }],
+
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],

--- a/packages/inference/jury/package.json
+++ b/packages/inference/jury/package.json
@@ -1,11 +1,14 @@
 {
   "name": "@seed/jury",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "test": "bun test",
     "typecheck": "bunx tsc --noEmit",
     "build": "tsc"
+  },
+  "dependencies": {
+    "@seed/inference-utils": "file:../utils"
   },
   "devDependencies": {
     "@types/bun": "latest"

--- a/packages/inference/jury/src/challenge.test.ts
+++ b/packages/inference/jury/src/challenge.test.ts
@@ -1,0 +1,382 @@
+import { describe, expect, test } from "bun:test";
+import { runChallenge, type ChallengeConfig, type ChallengerInvoke } from "./challenge";
+import type { InvokeResult, JurorResult } from "./types";
+
+function juror(id: string, content: string, error: string | null = null): JurorResult {
+  return { id, content, error, durationMs: 10, tokensPerSecond: 50 };
+}
+
+function findingsJson(
+  opts: {
+    contradictions?: string[];
+    errors?: string[];
+    gaps?: string[];
+    confidence?: number;
+    escalation_requested?: boolean;
+  } = {},
+): string {
+  return JSON.stringify({
+    contradictions: opts.contradictions ?? [],
+    errors: opts.errors ?? [],
+    gaps: opts.gaps ?? [],
+    confidence: opts.confidence ?? 0.9,
+    escalation_requested: opts.escalation_requested ?? false,
+  });
+}
+
+function makeInvoker(content: string | Error, delayMs = 0): ChallengerInvoke {
+  return async () => {
+    if (delayMs > 0) await new Promise((r) => setTimeout(r, delayMs));
+    if (content instanceof Error) throw content;
+    return { content, completionTokens: 20 } satisfies InvokeResult;
+  };
+}
+
+const jurors: JurorResult[] = [
+  juror("a", "Paris is the capital."),
+  juror("b", "The capital is Paris."),
+];
+
+const baseArgs = {
+  question: "what is the capital of france?",
+  jurors,
+};
+
+describe("runChallenge", () => {
+  test("parses findings and returns result at start tier", async () => {
+    const config: ChallengeConfig = {
+      enabled: true,
+      invokers: {
+        local: makeInvoker(
+          findingsJson({ errors: ["one juror missed punctuation"], confidence: 0.88 }),
+        ),
+      },
+    };
+    const result = await runChallenge({ ...baseArgs, config });
+    expect(result.tier).toBe("local");
+    expect(result.findings.confidence).toBe(0.88);
+    expect(result.findings.errors).toEqual(["one juror missed punctuation"]);
+    expect(result.attempts).toHaveLength(1);
+    expect(result.attempts[0].parseOk).toBe(true);
+    expect(result.escalationExhausted).toBe(false);
+    expect(result.cappedByTier).toBeNull();
+  });
+
+  test("escalates to midtier when local returns low confidence", async () => {
+    const config: ChallengeConfig = {
+      enabled: true,
+      escalate: true,
+      confidenceThreshold: 0.7,
+      invokers: {
+        local: makeInvoker(findingsJson({ confidence: 0.4 })),
+        midtier: makeInvoker(findingsJson({ confidence: 0.88, errors: ["fixed"] })),
+      },
+    };
+    const result = await runChallenge({ ...baseArgs, config });
+    expect(result.tier).toBe("midtier");
+    expect(result.findings.confidence).toBe(0.88);
+    expect(result.attempts).toHaveLength(2);
+    expect(result.attempts[0].tier).toBe("local");
+    expect(result.attempts[1].tier).toBe("midtier");
+  });
+
+  test("escalates when escalation_requested is true even if confidence is high", async () => {
+    const config: ChallengeConfig = {
+      enabled: true,
+      escalate: true,
+      invokers: {
+        local: makeInvoker(findingsJson({ confidence: 0.95, escalation_requested: true })),
+        midtier: makeInvoker(findingsJson({ confidence: 0.9 })),
+      },
+    };
+    const result = await runChallenge({ ...baseArgs, config });
+    expect(result.tier).toBe("midtier");
+  });
+
+  test("escalates on parse failure", async () => {
+    const config: ChallengeConfig = {
+      enabled: true,
+      escalate: true,
+      invokers: {
+        local: makeInvoker("not json at all, sorry"),
+        midtier: makeInvoker(findingsJson({ confidence: 0.9 })),
+      },
+    };
+    const result = await runChallenge({ ...baseArgs, config });
+    expect(result.tier).toBe("midtier");
+    expect(result.attempts[0].parseOk).toBe(false);
+    expect(result.attempts[1].parseOk).toBe(true);
+  });
+
+  test("stops at maxTier when set below frontier", async () => {
+    const config: ChallengeConfig = {
+      enabled: true,
+      escalate: true,
+      maxTier: "midtier",
+      invokers: {
+        local: makeInvoker(findingsJson({ confidence: 0.4 })),
+        midtier: makeInvoker(findingsJson({ confidence: 0.5 })),
+        frontier: makeInvoker(findingsJson({ confidence: 0.95 })),
+      },
+    };
+    const result = await runChallenge({ ...baseArgs, config });
+    expect(result.tier).toBe("midtier");
+    expect(result.findings.confidence).toBe(0.5);
+    expect(result.attempts).toHaveLength(2);
+  });
+
+  test("escalates through all three tiers when each requests escalation", async () => {
+    const config: ChallengeConfig = {
+      enabled: true,
+      escalate: true,
+      invokers: {
+        local: makeInvoker(findingsJson({ escalation_requested: true })),
+        midtier: makeInvoker(findingsJson({ escalation_requested: true })),
+        frontier: makeInvoker(findingsJson({ confidence: 0.98 })),
+      },
+    };
+    const result = await runChallenge({ ...baseArgs, config });
+    expect(result.tier).toBe("frontier");
+    expect(result.attempts.map((a) => a.tier)).toEqual(["local", "midtier", "frontier"]);
+  });
+
+  test("does not escalate when escalate:false", async () => {
+    const config: ChallengeConfig = {
+      enabled: true,
+      escalate: false,
+      invokers: {
+        local: makeInvoker(findingsJson({ confidence: 0.2 })),
+        midtier: makeInvoker(findingsJson({ confidence: 0.95 })),
+      },
+    };
+    const result = await runChallenge({ ...baseArgs, config });
+    expect(result.tier).toBe("local");
+    expect(result.findings.confidence).toBe(0.2);
+    expect(result.attempts).toHaveLength(1);
+  });
+
+  test("sensitivityLock + SENSITIVE forces maxTier to local", async () => {
+    const config: ChallengeConfig = {
+      enabled: true,
+      escalate: true,
+      sensitivityLock: true,
+      startTier: "local",
+      invokers: {
+        local: makeInvoker(findingsJson({ confidence: 0.3 })),
+        midtier: makeInvoker(findingsJson({ confidence: 0.9 })),
+      },
+    };
+    const result = await runChallenge({
+      ...baseArgs,
+      config,
+      sensitivity: "SENSITIVE",
+    });
+    expect(result.tier).toBe("local");
+    expect(result.cappedByTier).toBe("local");
+    // Only one attempt — escalation would go to midtier but cap blocks it.
+    expect(result.attempts).toHaveLength(1);
+  });
+
+  test("sensitivityLock + GENERAL does not cap", async () => {
+    const config: ChallengeConfig = {
+      enabled: true,
+      escalate: true,
+      sensitivityLock: true,
+      invokers: {
+        local: makeInvoker(findingsJson({ confidence: 0.3 })),
+        midtier: makeInvoker(findingsJson({ confidence: 0.9 })),
+      },
+    };
+    const result = await runChallenge({
+      ...baseArgs,
+      config,
+      sensitivity: "GENERAL",
+    });
+    expect(result.tier).toBe("midtier");
+    expect(result.cappedByTier).toBeNull();
+  });
+
+  test("downgrades startTier when it exceeds sensitivity cap", async () => {
+    const config: ChallengeConfig = {
+      enabled: true,
+      sensitivityLock: true,
+      startTier: "frontier",
+      invokers: {
+        local: makeInvoker(findingsJson({ confidence: 0.9 })),
+        frontier: makeInvoker(findingsJson({ confidence: 0.98 })),
+      },
+    };
+    const result = await runChallenge({
+      ...baseArgs,
+      config,
+      sensitivity: "SENSITIVE",
+    });
+    expect(result.tier).toBe("local");
+    expect(result.cappedByTier).toBe("local");
+  });
+
+  test("strict mode sets escalationExhausted when confidence stays below threshold", async () => {
+    const config: ChallengeConfig = {
+      enabled: true,
+      escalate: true,
+      strictness: "strict",
+      confidenceThreshold: 0.9,
+      invokers: {
+        local: makeInvoker(findingsJson({ confidence: 0.4 })),
+        midtier: makeInvoker(findingsJson({ confidence: 0.5 })),
+        frontier: makeInvoker(findingsJson({ confidence: 0.6 })),
+      },
+    };
+    const result = await runChallenge({ ...baseArgs, config });
+    expect(result.tier).toBe("frontier");
+    expect(result.escalationExhausted).toBe(true);
+  });
+
+  test("advisory mode never sets escalationExhausted from low confidence", async () => {
+    const config: ChallengeConfig = {
+      enabled: true,
+      escalate: true,
+      strictness: "advisory",
+      confidenceThreshold: 0.9,
+      invokers: {
+        local: makeInvoker(findingsJson({ confidence: 0.1 })),
+        midtier: makeInvoker(findingsJson({ confidence: 0.2 })),
+        frontier: makeInvoker(findingsJson({ confidence: 0.3 })),
+      },
+    };
+    const result = await runChallenge({ ...baseArgs, config });
+    expect(result.escalationExhausted).toBe(false);
+  });
+
+  test("skips tier when invoker missing, continues to next if escalate:true", async () => {
+    const config: ChallengeConfig = {
+      enabled: true,
+      escalate: true,
+      invokers: {
+        // No local invoker.
+        midtier: makeInvoker(findingsJson({ confidence: 0.9 })),
+      },
+    };
+    const result = await runChallenge({ ...baseArgs, config });
+    expect(result.tier).toBe("midtier");
+    expect(result.attempts[0].tier).toBe("local");
+    expect(result.attempts[0].error).toContain("no invoker configured");
+  });
+
+  test("returns empty findings + exhausted when all tiers fail", async () => {
+    const config: ChallengeConfig = {
+      enabled: true,
+      escalate: true,
+      invokers: {
+        local: makeInvoker("garbage"),
+        midtier: makeInvoker("also garbage"),
+        frontier: makeInvoker("still garbage"),
+      },
+    };
+    const result = await runChallenge({ ...baseArgs, config });
+    expect(result.findings.confidence).toBe(0);
+    expect(result.findings.contradictions).toEqual([]);
+    expect(result.escalationExhausted).toBe(true);
+    expect(result.attempts).toHaveLength(3);
+    expect(result.attempts.every((a) => !a.parseOk)).toBe(true);
+  });
+
+  test("captures invoker error in attempt", async () => {
+    const config: ChallengeConfig = {
+      enabled: true,
+      escalate: true,
+      invokers: {
+        local: makeInvoker(new Error("network timeout")),
+        midtier: makeInvoker(findingsJson({ confidence: 0.9 })),
+      },
+    };
+    const result = await runChallenge({ ...baseArgs, config });
+    expect(result.attempts[0].error).toBe("network timeout");
+    expect(result.tier).toBe("midtier");
+  });
+
+  test("handles JSON wrapped in markdown fences", async () => {
+    const wrapped = `Sure, here's the review:\n\`\`\`json\n${findingsJson({ confidence: 0.85 })}\n\`\`\``;
+    const config: ChallengeConfig = {
+      enabled: true,
+      invokers: { local: makeInvoker(wrapped) },
+    };
+    const result = await runChallenge({ ...baseArgs, config });
+    expect(result.findings.confidence).toBe(0.85);
+  });
+
+  test("handles JSON with <think> tags", async () => {
+    const wrapped = `<think>let me analyze...</think>${findingsJson({ confidence: 0.77 })}`;
+    const config: ChallengeConfig = {
+      enabled: true,
+      invokers: { local: makeInvoker(wrapped) },
+    };
+    const result = await runChallenge({ ...baseArgs, config });
+    expect(result.findings.confidence).toBe(0.77);
+  });
+
+  test("clamps confidence to [0, 1]", async () => {
+    const config: ChallengeConfig = {
+      enabled: true,
+      invokers: {
+        local: makeInvoker(JSON.stringify({ confidence: 1.5, contradictions: [], errors: [], gaps: [] })),
+      },
+    };
+    const result = await runChallenge({ ...baseArgs, config });
+    expect(result.findings.confidence).toBe(1);
+  });
+
+  test("rejects response with non-numeric confidence", async () => {
+    const config: ChallengeConfig = {
+      enabled: true,
+      escalate: false,
+      invokers: {
+        local: makeInvoker(
+          JSON.stringify({ confidence: "high", contradictions: [], errors: [], gaps: [] }),
+        ),
+      },
+    };
+    const result = await runChallenge({ ...baseArgs, config });
+    // Parse failure — confidence isn't a number, so findings aren't extracted.
+    expect(result.attempts[0].parseOk).toBe(false);
+    expect(result.escalationExhausted).toBe(true);
+  });
+
+  test("passes only valid jurors into the challenger prompt", async () => {
+    let captured = "";
+    const config: ChallengeConfig = {
+      enabled: true,
+      invokers: {
+        local: async (msgs) => {
+          captured = msgs[msgs.length - 1].content;
+          return { content: findingsJson({ confidence: 0.9 }) };
+        },
+      },
+    };
+    const jurorsWithFail: JurorResult[] = [
+      juror("ok1", "good response"),
+      juror("fail", "", "timeout"),
+      juror("ok2", "another good response"),
+    ];
+    await runChallenge({ question: "q", jurors: jurorsWithFail, config });
+    expect(captured).toContain("ok1");
+    expect(captured).toContain("ok2");
+    expect(captured).not.toContain("Juror 3 (fail)");
+  });
+
+  test("uses custom systemPrompt when provided", async () => {
+    let sysCaptured = "";
+    const config: ChallengeConfig = {
+      enabled: true,
+      systemPrompt: "you are a code reviewer",
+      invokers: {
+        local: async (msgs) => {
+          sysCaptured = msgs[0].content;
+          return { content: findingsJson({ confidence: 0.9 }) };
+        },
+      },
+    };
+    await runChallenge({ ...baseArgs, config });
+    expect(sysCaptured).toBe("you are a code reviewer");
+  });
+});

--- a/packages/inference/jury/src/challenge.ts
+++ b/packages/inference/jury/src/challenge.ts
@@ -1,0 +1,263 @@
+// Challenge round — after jurors return, a challenger model inspects
+// their outputs and emits structured findings (contradictions, errors,
+// gaps, confidence). Findings are woven into the aggregator's synthesis
+// prompt by the default aggregator.
+//
+// Tiered escalation: if `escalate:true` and the start-tier challenger
+// either (a) fails to emit parseable JSON, (b) returns confidence below
+// threshold, or (c) requests escalation, the challenge is retried at
+// the next tier — up to `maxTier`. A `sensitivityLock` cap forces
+// max_tier=local when the jury request carries sensitivity=SENSITIVE.
+
+import { extractJson, type JsonValue } from "@seed/inference-utils";
+import type { ChatMessage, InvokeOptions, InvokeResult, JurorResult } from "./types";
+import { minTier, nextTier, type Tier } from "./tiers";
+
+export type ChallengerInvoke = (
+  messages: ChatMessage[],
+  options: InvokeOptions,
+) => Promise<InvokeResult>;
+
+export type Sensitivity = "SENSITIVE" | "GENERAL" | "FRONTIER";
+
+export interface ChallengeConfig {
+  enabled: boolean;
+  /** One invoke fn per tier the caller wants to allow. At least the start-tier must be present. */
+  invokers: Partial<Record<Tier, ChallengerInvoke>>;
+  /** Tier to start at. Default: "local". */
+  startTier?: Tier;
+  /** If true, escalate on low confidence / parse fail / escalation_requested. Default: false. */
+  escalate?: boolean;
+  /** Inclusive cap on escalation. Default: "frontier". */
+  maxTier?: Tier;
+  /** Confidence below this triggers escalation. Default: 0.7. */
+  confidenceThreshold?: number;
+  /**
+   * "advisory": findings always pass through; aggregator proceeds.
+   * "strict": findings still pass through, but `escalationExhausted`
+   * is set on the result when a low-confidence finding survives
+   * all escalation rounds, so callers can gate themselves.
+   * Default: "advisory".
+   */
+  strictness?: "advisory" | "strict";
+  /** If true, SENSITIVE sensitivity forces maxTier=local. Default: false. */
+  sensitivityLock?: boolean;
+  /** Max tokens for challenger output. Default: 512. */
+  maxTokens?: number;
+  /** Override the default challenger system prompt. */
+  systemPrompt?: string;
+}
+
+export interface ChallengeFindings {
+  contradictions: string[];
+  errors: string[];
+  gaps: string[];
+  confidence: number;
+  escalationRequested: boolean;
+}
+
+export interface ChallengeAttempt {
+  tier: Tier;
+  raw: string;
+  parseOk: boolean;
+  confidence: number | null;
+  durationMs: number;
+  error: string | null;
+}
+
+export interface ChallengeResult {
+  findings: ChallengeFindings;
+  tier: Tier;
+  attempts: ChallengeAttempt[];
+  durationMs: number;
+  cappedByTier: Tier | null;
+  escalationExhausted: boolean;
+}
+
+const DEFAULT_SYSTEM_PROMPT =
+  "You are a quality reviewer comparing multiple model responses. Identify contradictions between responses, errors in reasoning or fact, and gaps that none of the respondents addressed. Be precise and brief. Respond ONLY with a JSON object matching the schema below; do not include commentary, markdown, or <think> tags.";
+
+const DEFAULT_MAX_TOKENS = 512;
+const DEFAULT_CONFIDENCE_THRESHOLD = 0.7;
+const DEFAULT_START_TIER: Tier = "local";
+const DEFAULT_MAX_TIER: Tier = "frontier";
+
+interface RunChallengeArgs {
+  question: string;
+  jurors: JurorResult[];
+  config: ChallengeConfig;
+  sensitivity?: Sensitivity;
+}
+
+export async function runChallenge({
+  question,
+  jurors,
+  config,
+  sensitivity,
+}: RunChallengeArgs): Promise<ChallengeResult> {
+  const start = Date.now();
+  const systemPrompt = config.systemPrompt ?? DEFAULT_SYSTEM_PROMPT;
+  const maxTokens = config.maxTokens ?? DEFAULT_MAX_TOKENS;
+  const threshold = config.confidenceThreshold ?? DEFAULT_CONFIDENCE_THRESHOLD;
+  const strict = (config.strictness ?? "advisory") === "strict";
+  const escalateEnabled = config.escalate === true;
+
+  let effectiveMaxTier = config.maxTier ?? DEFAULT_MAX_TIER;
+  let cappedByTier: Tier | null = null;
+  if (config.sensitivityLock && sensitivity === "SENSITIVE") {
+    cappedByTier = minTier(effectiveMaxTier, "local");
+    effectiveMaxTier = cappedByTier;
+  }
+
+  // If start tier is above the cap, downgrade it.
+  let tier: Tier = config.startTier ?? DEFAULT_START_TIER;
+  tier = minTier(tier, effectiveMaxTier);
+
+  const validJurors = jurors.filter((j) => !j.error && j.content.length > 0);
+  const userPrompt = buildUserPrompt(question, validJurors);
+  const messages: ChatMessage[] = [
+    { role: "system", content: systemPrompt },
+    { role: "user", content: userPrompt },
+  ];
+
+  const attempts: ChallengeAttempt[] = [];
+  let finalFindings: ChallengeFindings | null = null;
+  let finalTier: Tier = tier;
+
+  while (true) {
+    const invoke = config.invokers[tier];
+    if (!invoke) {
+      attempts.push({
+        tier,
+        raw: "",
+        parseOk: false,
+        confidence: null,
+        durationMs: 0,
+        error: `no invoker configured for tier "${tier}"`,
+      });
+      if (!escalateEnabled) break;
+      const next = nextTier(tier, effectiveMaxTier);
+      if (!next) break;
+      tier = next;
+      continue;
+    }
+
+    const attemptStart = Date.now();
+    let raw = "";
+    let error: string | null = null;
+    try {
+      const res = await invoke(messages, { temperature: 0.3, maxTokens });
+      raw = res.content;
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err);
+    }
+    const durationMs = Date.now() - attemptStart;
+
+    const parsed = error ? null : tryParseFindings(raw);
+    const parseOk = parsed !== null;
+    const confidence = parsed?.confidence ?? null;
+
+    attempts.push({ tier, raw, parseOk, confidence, durationMs, error });
+
+    if (parsed) {
+      finalFindings = parsed;
+      finalTier = tier;
+      const needsEscalation =
+        escalateEnabled &&
+        (parsed.escalationRequested || parsed.confidence < threshold);
+      if (!needsEscalation) break;
+    } else if (!escalateEnabled) {
+      break;
+    }
+
+    const next = nextTier(tier, effectiveMaxTier);
+    if (!next) break;
+    tier = next;
+  }
+
+  if (!finalFindings) {
+    // All attempts failed to produce parseable findings. Return an
+    // empty-findings result flagged as exhausted so callers can see
+    // that the challenger didn't produce a verdict.
+    return {
+      findings: emptyFindings(),
+      tier: finalTier,
+      attempts,
+      durationMs: Date.now() - start,
+      cappedByTier,
+      escalationExhausted: true,
+    };
+  }
+
+  const escalationExhausted =
+    strict && finalFindings.confidence < threshold && attempts.length > 0;
+
+  return {
+    findings: finalFindings,
+    tier: finalTier,
+    attempts,
+    durationMs: Date.now() - start,
+    cappedByTier,
+    escalationExhausted,
+  };
+}
+
+function buildUserPrompt(question: string, jurors: JurorResult[]): string {
+  const analyses = jurors
+    .map((j, i) => {
+      const label = j.role ? `${j.role} — ${j.id}` : j.id;
+      return `--- Juror ${i + 1} (${label}) ---\n${j.content}`;
+    })
+    .join("\n\n");
+
+  return `Question: ${question}
+
+Juror responses:
+${analyses}
+
+Schema:
+{
+  "contradictions": [string, ...],  // specific disagreements between jurors
+  "errors": [string, ...],           // factual or reasoning mistakes
+  "gaps": [string, ...],             // issues none of the jurors addressed
+  "confidence": number,              // 0.0-1.0, your confidence in this review
+  "escalation_requested": boolean    // true if a stronger reviewer is needed
+}
+
+Respond with JSON only.`;
+}
+
+function tryParseFindings(raw: string): ChallengeFindings | null {
+  const parsed = extractJson(raw);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  const obj = parsed as Record<string, JsonValue>;
+
+  const contradictions = coerceStringArray(obj.contradictions);
+  const errors = coerceStringArray(obj.errors);
+  const gaps = coerceStringArray(obj.gaps);
+  const confidence = coerceConfidence(obj.confidence);
+  const escalationRequested = obj.escalation_requested === true;
+
+  if (confidence === null) return null;
+  return { contradictions, errors, gaps, confidence, escalationRequested };
+}
+
+function coerceStringArray(v: JsonValue | undefined): string[] {
+  if (!Array.isArray(v)) return [];
+  return v.filter((x): x is string => typeof x === "string" && x.length > 0);
+}
+
+function coerceConfidence(v: JsonValue | undefined): number | null {
+  if (typeof v !== "number" || Number.isNaN(v)) return null;
+  return Math.max(0, Math.min(1, v));
+}
+
+function emptyFindings(): ChallengeFindings {
+  return {
+    contradictions: [],
+    errors: [],
+    gaps: [],
+    confidence: 0,
+    escalationRequested: false,
+  };
+}

--- a/packages/inference/jury/src/default-aggregator.ts
+++ b/packages/inference/jury/src/default-aggregator.ts
@@ -6,7 +6,12 @@
 // not mention the synthesis process. That framing reliably produces
 // single-voice output instead of "Juror 1 said X, but Juror 2 said Y"
 // summaries.
+//
+// When a challenge round has run, findings are threaded into the
+// synthesis prompt so the aggregator can correct errors and address
+// gaps flagged by the reviewer.
 
+import type { ChallengeFindings } from "./challenge";
 import type { AggregatorFn, ChatMessage, InvokeResult, JurorResult } from "./types";
 
 export interface DefaultAggregatorOptions {
@@ -26,21 +31,25 @@ export interface DefaultAggregatorOptions {
 export function makeDefaultAggregator(options: DefaultAggregatorOptions): AggregatorFn {
   const temperature = options.temperature ?? 0.3;
 
-  return async function defaultAggregator({ question, jurors, maxTokens }) {
+  return async function defaultAggregator({ question, jurors, maxTokens, challenge }) {
     const valid = jurors.filter((j) => !j.error && j.content.length > 0);
     if (valid.length === 0) throw new Error("All jurors failed");
     if (valid.length === 1) return valid[0].content;
 
     const responsesText = valid.map((j, i) => formatJuror(j, i)).join("\n\n");
+    const challengeBlock = challenge ? formatChallengeBlock(challenge.findings) : "";
+    const correctionInstruction = challenge && hasFindings(challenge.findings)
+      ? " Incorporate corrections and addressed gaps from the quality review."
+      : "";
 
     const aggregationPrompt = `You are synthesizing ${valid.length} model responses into one best answer. Be concise and direct.
 
 Question: ${question}
 
 Responses:
-${responsesText}
+${responsesText}${challengeBlock}
 
-Synthesize into a single best response. Take the strongest elements from each. Do not mention the jurors or the synthesis process.`;
+Synthesize into a single best response. Take the strongest elements from each.${correctionInstruction} Do not mention the jurors, the quality review, or the synthesis process.`;
 
     const systemPrompt = options.systemPrompt;
     const messages: ChatMessage[] = [];
@@ -55,4 +64,31 @@ Synthesize into a single best response. Take the strongest elements from each. D
 function formatJuror(juror: JurorResult, index: number): string {
   const label = juror.role ? `${juror.role} — ${juror.id}` : juror.id;
   return `[Juror ${index + 1} (${label})]:\n${juror.content}`;
+}
+
+function formatChallengeBlock(findings: ChallengeFindings): string {
+  if (!hasFindings(findings)) return "";
+  const parts: string[] = [];
+  if (findings.contradictions.length > 0) {
+    parts.push(`Contradictions:\n${bulletize(findings.contradictions)}`);
+  }
+  if (findings.errors.length > 0) {
+    parts.push(`Errors:\n${bulletize(findings.errors)}`);
+  }
+  if (findings.gaps.length > 0) {
+    parts.push(`Gaps:\n${bulletize(findings.gaps)}`);
+  }
+  return `\n\n--- Quality review ---\n${parts.join("\n\n")}`;
+}
+
+function bulletize(items: string[]): string {
+  return items.map((s) => `- ${s}`).join("\n");
+}
+
+function hasFindings(findings: ChallengeFindings): boolean {
+  return (
+    findings.contradictions.length > 0 ||
+    findings.errors.length > 0 ||
+    findings.gaps.length > 0
+  );
 }

--- a/packages/inference/jury/src/index.ts
+++ b/packages/inference/jury/src/index.ts
@@ -1,7 +1,18 @@
 export { runJury } from "./jury";
 export { calculateAgreement } from "./agreement";
 export { makeDefaultAggregator } from "./default-aggregator";
+export { runChallenge } from "./challenge";
+export { TIER_ORDER, tierRank, nextTier, minTier } from "./tiers";
 export type { DefaultAggregatorOptions } from "./default-aggregator";
+export type {
+  ChallengeAttempt,
+  ChallengeConfig,
+  ChallengeFindings,
+  ChallengeResult,
+  ChallengerInvoke,
+  Sensitivity,
+} from "./challenge";
+export type { Tier } from "./tiers";
 export type {
   AggregatorContext,
   AggregatorFn,

--- a/packages/inference/jury/src/jury-challenge.test.ts
+++ b/packages/inference/jury/src/jury-challenge.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, test } from "bun:test";
+import { runJury } from "./jury";
+import { makeDefaultAggregator } from "./default-aggregator";
+import type { ChallengeConfig } from "./challenge";
+import type {
+  ChatMessage,
+  InvokeResult,
+  JurorAssignment,
+  JuryRequest,
+} from "./types";
+
+function juror(id: string, content: string): JurorAssignment {
+  return {
+    id,
+    invoke: async (): Promise<InvokeResult> => ({ content, completionTokens: 10 }),
+  };
+}
+
+const baseMessages: ChatMessage[] = [
+  { role: "user", content: "what is the capital of france?" },
+];
+
+function findingsJson(confidence = 0.9, escalation_requested = false): string {
+  return JSON.stringify({
+    contradictions: [],
+    errors: ["one juror drifted off-topic"],
+    gaps: [],
+    confidence,
+    escalation_requested,
+  });
+}
+
+describe("runJury + challenge integration", () => {
+  test("runs challenge when enabled and includes findings in response", async () => {
+    const config: ChallengeConfig = {
+      enabled: true,
+      invokers: {
+        local: async () => ({ content: findingsJson() }),
+      },
+    };
+    const res = await runJury({
+      messages: baseMessages,
+      jurors: [juror("a", "Paris"), juror("b", "Paris.")],
+      aggregator: async () => "Paris.",
+      challenge: config,
+    });
+    expect(res.challenge).toBeDefined();
+    expect(res.challenge!.findings.errors).toEqual(["one juror drifted off-topic"]);
+    expect(res.challenge!.tier).toBe("local");
+  });
+
+  test("skips challenge when enabled:false", async () => {
+    const res = await runJury({
+      messages: baseMessages,
+      jurors: [juror("a", "Paris"), juror("b", "Paris.")],
+      aggregator: async () => "Paris.",
+      challenge: { enabled: false, invokers: {} },
+    });
+    expect(res.challenge).toBeUndefined();
+  });
+
+  test("skips challenge when challenge undefined", async () => {
+    const res = await runJury({
+      messages: baseMessages,
+      jurors: [juror("a", "Paris"), juror("b", "Paris.")],
+      aggregator: async () => "Paris.",
+    });
+    expect(res.challenge).toBeUndefined();
+  });
+
+  test("passes challenge findings to aggregator context", async () => {
+    let received: unknown = null;
+    const config: ChallengeConfig = {
+      enabled: true,
+      invokers: {
+        local: async () => ({ content: findingsJson(0.82) }),
+      },
+    };
+    await runJury({
+      messages: baseMessages,
+      jurors: [juror("a", "Paris"), juror("b", "Paris.")],
+      aggregator: async (ctx) => {
+        received = ctx.challenge;
+        return "ok";
+      },
+      challenge: config,
+    });
+    expect(received).not.toBeNull();
+    const r = received as { tier: string; findings: { confidence: number } };
+    expect(r.tier).toBe("local");
+    expect(r.findings.confidence).toBe(0.82);
+  });
+
+  test("fires onChallengeComplete telemetry hook", async () => {
+    let captured: unknown = null;
+    const req: JuryRequest = {
+      messages: baseMessages,
+      jurors: [juror("a", "Paris"), juror("b", "Paris.")],
+      aggregator: async () => "Paris.",
+      challenge: {
+        enabled: true,
+        invokers: { local: async () => ({ content: findingsJson() }) },
+      },
+      onChallengeComplete: (r) => {
+        captured = r;
+      },
+    };
+    await runJury(req);
+    expect(captured).not.toBeNull();
+  });
+
+  test("default aggregator weaves findings into prompt", async () => {
+    let sentPrompt = "";
+    const aggregator = makeDefaultAggregator({
+      invoke: async (msgs) => {
+        sentPrompt = msgs[msgs.length - 1].content;
+        return { content: "synthesized" };
+      },
+    });
+    const config: ChallengeConfig = {
+      enabled: true,
+      invokers: {
+        local: async () =>
+          ({
+            content: JSON.stringify({
+              contradictions: ["A says X, B says Y"],
+              errors: ["B miscounted"],
+              gaps: ["neither addressed time-of-day"],
+              confidence: 0.85,
+              escalation_requested: false,
+            }),
+          }),
+      },
+    };
+    await runJury({
+      messages: baseMessages,
+      jurors: [juror("a", "A-response"), juror("b", "B-response")],
+      aggregator,
+      challenge: config,
+    });
+    expect(sentPrompt).toContain("Quality review");
+    expect(sentPrompt).toContain("A says X, B says Y");
+    expect(sentPrompt).toContain("B miscounted");
+    expect(sentPrompt).toContain("neither addressed time-of-day");
+    expect(sentPrompt).toContain("Incorporate corrections");
+  });
+
+  test("default aggregator skips review block when findings empty", async () => {
+    let sentPrompt = "";
+    const aggregator = makeDefaultAggregator({
+      invoke: async (msgs) => {
+        sentPrompt = msgs[msgs.length - 1].content;
+        return { content: "synthesized" };
+      },
+    });
+    const config: ChallengeConfig = {
+      enabled: true,
+      invokers: {
+        local: async () =>
+          ({
+            content: JSON.stringify({
+              contradictions: [],
+              errors: [],
+              gaps: [],
+              confidence: 0.95,
+              escalation_requested: false,
+            }),
+          }),
+      },
+    };
+    await runJury({
+      messages: baseMessages,
+      jurors: [juror("a", "A-response"), juror("b", "B-response")],
+      aggregator,
+      challenge: config,
+    });
+    expect(sentPrompt).not.toContain("Quality review");
+    expect(sentPrompt).not.toContain("Incorporate corrections");
+  });
+
+  test("sensitivity=SENSITIVE + sensitivityLock forces local tier", async () => {
+    let localCalls = 0;
+    let midtierCalls = 0;
+    const config: ChallengeConfig = {
+      enabled: true,
+      escalate: true,
+      sensitivityLock: true,
+      invokers: {
+        local: async () => {
+          localCalls++;
+          return { content: findingsJson(0.3) };
+        },
+        midtier: async () => {
+          midtierCalls++;
+          return { content: findingsJson(0.9) };
+        },
+      },
+    };
+    const res = await runJury({
+      messages: baseMessages,
+      jurors: [juror("a", "Paris"), juror("b", "Paris.")],
+      aggregator: async () => "ok",
+      challenge: config,
+      sensitivity: "SENSITIVE",
+    });
+    expect(localCalls).toBe(1);
+    expect(midtierCalls).toBe(0);
+    expect(res.challenge!.cappedByTier).toBe("local");
+  });
+});

--- a/packages/inference/jury/src/jury.ts
+++ b/packages/inference/jury/src/jury.ts
@@ -5,6 +5,8 @@
 // their outputs differ meaningfully even when they share a base model.
 
 import { calculateAgreement } from "./agreement";
+import { runChallenge } from "./challenge";
+import type { ChallengeResult } from "./challenge";
 import type {
   InvokeOptions,
   JurorAssignment,
@@ -17,7 +19,17 @@ const DEFAULT_TEMPERATURES = [0.3, 0.5, 0.7, 0.9];
 const DEFAULT_MAX_TOKENS = 512;
 
 export async function runJury(request: JuryRequest): Promise<JuryResponse> {
-  const { jurors, messages, aggregator, queue, onJurorComplete, onAggregateComplete } = request;
+  const {
+    jurors,
+    messages,
+    aggregator,
+    queue,
+    onJurorComplete,
+    onAggregateComplete,
+    onChallengeComplete,
+    challenge: challengeConfig,
+    sensitivity,
+  } = request;
 
   if (jurors.length === 0) {
     throw new Error("runJury: jurors[] is empty");
@@ -38,10 +50,26 @@ export async function runJury(request: JuryRequest): Promise<JuryResponse> {
     }),
   );
 
+  let challengeResult: ChallengeResult | undefined;
+  if (challengeConfig?.enabled) {
+    challengeResult = await runChallenge({
+      question: lastUserMsg,
+      jurors: jurorResults,
+      config: challengeConfig,
+      sensitivity,
+    });
+    onChallengeComplete?.(challengeResult);
+  }
+
   const aggregateStart = Date.now();
   let consensus: string;
   try {
-    consensus = await aggregator({ question: lastUserMsg, jurors: jurorResults, maxTokens });
+    consensus = await aggregator({
+      question: lastUserMsg,
+      jurors: jurorResults,
+      maxTokens,
+      challenge: challengeResult,
+    });
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);
     onAggregateComplete?.({
@@ -66,6 +94,7 @@ export async function runJury(request: JuryRequest): Promise<JuryResponse> {
     agreement,
     aggregateDurationMs,
     totalDurationMs: Date.now() - start,
+    challenge: challengeResult,
   };
 }
 

--- a/packages/inference/jury/src/tiers.test.ts
+++ b/packages/inference/jury/src/tiers.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { minTier, nextTier, TIER_ORDER, tierRank } from "./tiers";
+
+describe("tiers", () => {
+  test("TIER_ORDER is local < midtier < frontier", () => {
+    expect(TIER_ORDER).toEqual(["local", "midtier", "frontier"]);
+  });
+
+  test("tierRank returns index", () => {
+    expect(tierRank("local")).toBe(0);
+    expect(tierRank("midtier")).toBe(1);
+    expect(tierRank("frontier")).toBe(2);
+  });
+
+  test("nextTier returns next when below max", () => {
+    expect(nextTier("local", "frontier")).toBe("midtier");
+    expect(nextTier("midtier", "frontier")).toBe("frontier");
+  });
+
+  test("nextTier returns null when at max", () => {
+    expect(nextTier("frontier", "frontier")).toBeNull();
+    expect(nextTier("midtier", "midtier")).toBeNull();
+    expect(nextTier("local", "local")).toBeNull();
+  });
+
+  test("nextTier returns null when already above max", () => {
+    expect(nextTier("frontier", "local")).toBeNull();
+    expect(nextTier("midtier", "local")).toBeNull();
+  });
+
+  test("minTier returns lower of two", () => {
+    expect(minTier("local", "frontier")).toBe("local");
+    expect(minTier("frontier", "local")).toBe("local");
+    expect(minTier("midtier", "frontier")).toBe("midtier");
+    expect(minTier("midtier", "midtier")).toBe("midtier");
+  });
+});

--- a/packages/inference/jury/src/tiers.ts
+++ b/packages/inference/jury/src/tiers.ts
@@ -1,0 +1,23 @@
+// Tier ordering and helpers for challenge-round escalation.
+
+export type Tier = "local" | "midtier" | "frontier";
+
+export const TIER_ORDER: readonly Tier[] = ["local", "midtier", "frontier"];
+
+/** Returns index within TIER_ORDER. "local" = 0, "frontier" = 2. */
+export function tierRank(tier: Tier): number {
+  return TIER_ORDER.indexOf(tier);
+}
+
+/** Return the next tier above `from`, or null if `from` is already at `max`. */
+export function nextTier(from: Tier, max: Tier): Tier | null {
+  const fromIdx = tierRank(from);
+  const maxIdx = tierRank(max);
+  if (fromIdx >= maxIdx) return null;
+  return TIER_ORDER[fromIdx + 1];
+}
+
+/** Return the lower of two tiers (min by rank). */
+export function minTier(a: Tier, b: Tier): Tier {
+  return tierRank(a) <= tierRank(b) ? a : b;
+}

--- a/packages/inference/jury/src/types.ts
+++ b/packages/inference/jury/src/types.ts
@@ -6,6 +6,8 @@
 // transport — callers supply `invoke` functions that wrap whichever
 // backend (local Ollama, MLX, cloud) they want to use.
 
+import type { ChallengeConfig, ChallengeResult, Sensitivity } from "./challenge";
+
 export interface ChatMessage {
   role: "system" | "user" | "assistant";
   content: string;
@@ -53,6 +55,8 @@ export interface AggregatorContext {
   question: string;
   jurors: JurorResult[];
   maxTokens: number;
+  /** Challenge findings if the challenge round ran. Undefined if challenge disabled. */
+  challenge?: ChallengeResult;
 }
 
 /**
@@ -74,6 +78,12 @@ export interface JuryRequest {
   onJurorComplete?: (result: JurorResult) => void;
   /** Telemetry hook fired once after aggregation completes. */
   onAggregateComplete?: (info: { durationMs: number; status: "success" | "error"; error?: string }) => void;
+  /** Optional challenge round — after jurors return, a reviewer inspects their outputs. */
+  challenge?: ChallengeConfig;
+  /** Classification for the request. Used when challenge.sensitivityLock is true. */
+  sensitivity?: Sensitivity;
+  /** Telemetry hook fired after the challenge round completes. */
+  onChallengeComplete?: (result: ChallengeResult) => void;
 }
 
 export interface JuryResponse {
@@ -82,4 +92,6 @@ export interface JuryResponse {
   agreement: number;
   aggregateDurationMs: number;
   totalDurationMs: number;
+  /** Present when challenge round ran. */
+  challenge?: ChallengeResult;
 }


### PR DESCRIPTION
## Summary
Bumps \`@seed/jury\` to 0.2.0. After jurors return, an optional challenger model inspects their outputs and emits structured findings. Findings pass through to the default aggregator's synthesis prompt so the final consensus incorporates corrections.

## Escalation
- Tier order: **local → midtier → frontier** (\`@seed/jury\` → \`tiers.ts\`)
- \`escalate: true\` retries at next tier when the challenger returns:
  - parseable JSON with confidence below threshold, OR
  - \`escalation_requested: true\`, OR
  - a parse failure (non-JSON response)
- \`maxTier\` caps the ceiling (default \`frontier\`)
- \`sensitivityLock: true\` + \`sensitivity: 'SENSITIVE'\` on the jury request caps \`maxTier\` to \`local\` — SENSITIVE content stays on the fleet

## Strictness
- **advisory** (default): findings always pass through; synthesis proceeds
- **strict**: still pass-through, but \`escalationExhausted: true\` surfaces on the result when confidence remains below threshold after escalation, giving callers a gate signal

## Findings weaving
The default aggregator injects a \`--- Quality review ---\` block above the closing instruction with bulletized contradictions/errors/gaps, and adds \"Incorporate corrections and addressed gaps\" when any are present. Block omitted entirely when findings are empty.

## Wire format
Challenger is asked for:
\`\`\`json
{
  \"contradictions\": [string, ...],
  \"errors\": [string, ...],
  \"gaps\": [string, ...],
  \"confidence\": number,
  \"escalation_requested\": boolean
}
\`\`\`
Parsed via \`@seed/inference-utils\` → handles \`<think>\` tags, markdown fences, and prose surrounds. Confidence clamped to [0, 1].

## Context
Final arc of three:
- **A:** \`@seed/jury\` primitive (phyter1/seed#11)
- **C:** cloud adapter runtime (phyter1/seed#12)
- **B (this PR):** challenge round

**Base is** \`main\` but the PR includes A and C. Review-order recommendation: merge #11 first, then #12, then this — diff will auto-narrow. Or if you want to merge all three together it's self-contained.

## Test plan
- [x] \`bun test\` — 65 tests pass (30 preexisting + 22 challenge + 6 tiers + 7 integration)
- [x] \`bunx tsc --noEmit\` — clean
- [x] gitleaks clean on push