### PR TITLE
feat(fleet): cli.update command + dispatch from seed fleet upgrade

### DIFF
--- a/packages/fleet/control/package.json
+++ b/packages/fleet/control/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seed/fleet-control",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "type": "module",
   "scripts": {
     "server": "bun run src/main.ts",

--- a/packages/fleet/control/src/agent.test.ts
+++ b/packages/fleet/control/src/agent.test.ts
@@ -1,0 +1,91 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { findCliPath, getCliVersion } from "./agent";
+import { mkdtempSync, writeFileSync, chmodSync, rmSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+describe("findCliPath", () => {
+  let fakeHome: string;
+  let originalHome: string | undefined;
+
+  beforeAll(() => {
+    fakeHome = mkdtempSync(join(tmpdir(), "seed-cli-path-"));
+    originalHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+  });
+
+  afterAll(() => {
+    process.env.HOME = originalHome;
+    rmSync(fakeHome, { recursive: true, force: true });
+  });
+
+  test("returns null when no CLI is installed anywhere", () => {
+    // fakeHome has no .local/bin, and system paths don't have 'seed'
+    // (or if they do, they're not under our control — this is still a
+    // useful assertion that the function returns a string or null, not
+    // throws)
+    const result = findCliPath();
+    // On a dev machine with seed installed, this could be non-null if
+    // the system path has it. Only assert the type contract.
+    expect(result === null || typeof result === "string").toBe(true);
+  });
+
+  test("finds executable at ~/.local/bin/seed when present", () => {
+    const binDir = join(fakeHome, ".local", "bin");
+    mkdirSync(binDir, { recursive: true });
+    const seedPath = join(binDir, "seed");
+    writeFileSync(seedPath, "#!/bin/sh\necho fake");
+    chmodSync(seedPath, 0o755);
+
+    expect(findCliPath()).toBe(seedPath);
+  });
+});
+
+describe("getCliVersion", () => {
+  let tmpDir: string;
+
+  beforeAll(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "seed-cli-ver-"));
+  });
+
+  afterAll(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("extracts semver from binary output", () => {
+    const fake = join(tmpDir, "fake-cli");
+    writeFileSync(fake, "#!/bin/sh\necho 0.4.3");
+    chmodSync(fake, 0o755);
+
+    expect(getCliVersion(fake)).toBe("0.4.3");
+  });
+
+  test("extracts semver from prefixed output", () => {
+    const fake = join(tmpDir, "fake-cli-prefix");
+    writeFileSync(fake, "#!/bin/sh\necho 'seed-cli 1.23.456 built 2026-01-01'");
+    chmodSync(fake, 0o755);
+
+    expect(getCliVersion(fake)).toBe("1.23.456");
+  });
+
+  test("returns null when binary fails to execute", () => {
+    const fake = join(tmpDir, "nonexistent");
+    expect(getCliVersion(fake)).toBeNull();
+  });
+
+  test("returns null when output has no version string", () => {
+    const fake = join(tmpDir, "no-version");
+    writeFileSync(fake, "#!/bin/sh\necho 'no version here'");
+    chmodSync(fake, 0o755);
+
+    expect(getCliVersion(fake)).toBeNull();
+  });
+
+  test("returns null when binary exits non-zero", () => {
+    const fake = join(tmpDir, "exit-fail");
+    writeFileSync(fake, "#!/bin/sh\necho 0.4.3\nexit 1");
+    chmodSync(fake, 0o755);
+
+    expect(getCliVersion(fake)).toBeNull();
+  });
+});

--- a/packages/fleet/control/src/agent.ts
+++ b/packages/fleet/control/src/agent.ts
@@ -528,6 +528,47 @@ type CommandHandler = (
   params: Record<string, unknown>
 ) => Promise<{ success: boolean; output: string }>;
 
+/**
+ * Locate the seed-cli binary on this machine, if installed.
+ *
+ * Checks canonical install paths. Returns the first executable match or
+ * null. We don't shell out to `which` because PATH in the agent's
+ * launchd context is narrow and unreliable for operator binaries.
+ */
+export function findCliPath(): string | null {
+  const fs = require("fs");
+  const home = process.env.HOME ?? "";
+  const candidates = [
+    `${home}/.local/bin/seed`,
+    `${home}/.local/bin/seed-cli`,
+    "/usr/local/bin/seed",
+    "/opt/homebrew/bin/seed",
+  ];
+  for (const p of candidates) {
+    try {
+      fs.accessSync(p, fs.constants.X_OK);
+      return p;
+    } catch {}
+  }
+  return null;
+}
+
+/**
+ * Read the version of a seed-cli binary by execing it with `version`.
+ * Returns null if the invocation fails or output is unparseable.
+ */
+export function getCliVersion(cliPath: string): string | null {
+  try {
+    const proc = Bun.spawnSync([cliPath, "version"]);
+    if (proc.exitCode !== 0) return null;
+    const out = new TextDecoder().decode(proc.stdout).trim();
+    const match = out.match(/\d+\.\d+\.\d+/);
+    return match ? match[0] : null;
+  } catch {
+    return null;
+  }
+}
+
 function createCommandHandlers(): Map<string, CommandHandler> {
   const handlers = new Map<string, CommandHandler>();
 
@@ -577,6 +618,40 @@ function createCommandHandlers(): Map<string, CommandHandler> {
     console.log("[agent] restart requested, exiting for supervisor to restart...");
     setTimeout(() => process.exit(0), 500);
     return { success: true, output: "restarting" };
+  });
+
+  handlers.set("cli.update", async (params) => {
+    const cliPath = findCliPath();
+    if (!cliPath) {
+      return {
+        success: true,
+        output: "no seed-cli found on this machine, skipping",
+      };
+    }
+    const currentVersion = getCliVersion(cliPath) ?? "unknown";
+    const version =
+      typeof params.version === "string" ? params.version : undefined;
+    const force = params.force === true;
+    try {
+      const result = await runSelfUpdate({
+        binary: "seed-cli",
+        version,
+        currentVersion,
+        force,
+        destPath: cliPath,
+      });
+      return {
+        success: true,
+        output: result.updated
+          ? `seed-cli updated ${result.fromVersion} -> ${result.toVersion} at ${cliPath}`
+          : `seed-cli already at ${result.toVersion}, no-op`,
+      };
+    } catch (err: any) {
+      return {
+        success: false,
+        output: `cli self-update failed: ${err?.message ?? err}`,
+      };
+    }
   });
 
   handlers.set("agent.update", async (params) => {
@@ -1192,7 +1267,11 @@ async function entrypoint() {
   await runAgent();
 }
 
-entrypoint().catch((err) => {
-  console.error("[agent] fatal:", err);
-  process.exit(1);
-});
+// Only start the agent when this module is invoked directly, not when
+// imported by tests. Mirrors the pattern used in cli.ts.
+if (import.meta.main) {
+  entrypoint().catch((err) => {
+    console.error("[agent] fatal:", err);
+    process.exit(1);
+  });
+}

--- a/packages/fleet/control/src/cli.ts
+++ b/packages/fleet/control/src/cli.ts
@@ -688,16 +688,102 @@ async function upgradeOneMachine(
     targetVersion,
     timeoutMs
   );
-  if (ok) {
-    console.log(`OK (${observed})`);
-    return { machineId, ok: true, message: `upgraded to ${observed}` };
+  if (!ok) {
+    console.log(`TIMEOUT (last observed: ${observed ?? "none"})`);
+    return {
+      machineId,
+      ok: false,
+      message: `timeout; last observed version: ${observed ?? "none"}`,
+    };
   }
-  console.log(`TIMEOUT (last observed: ${observed ?? "none"})`);
+  process.stdout.write(`agent OK (${observed}). cli.update... `);
+
+  // After the agent reconnects at the new version, ask it to update the
+  // seed-cli binary on the same machine (best-effort — a pure agent-only
+  // host with no CLI will report skip, which we count as success).
+  // Dispatch is fire-and-forget over HTTP; the command result comes back
+  // via the agent's WebSocket and lands in the audit log, so we poll
+  // there for the outcome.
+  let dispatch: { command_id?: string };
+  try {
+    dispatch = (await apiPost(`/v1/fleet/${machineId}/command`, {
+      action: "cli.update",
+      params: { version: tag },
+      timeout_ms: 60_000,
+    })) as { command_id?: string };
+  } catch (err: any) {
+    const cliMessage = `cli.update dispatch failed: ${err?.message ?? err}`;
+    console.log(cliMessage);
+    return {
+      machineId,
+      ok: true,
+      message: `agent upgraded to ${observed}; ${cliMessage}`,
+    };
+  }
+
+  const commandId = dispatch.command_id;
+  if (!commandId) {
+    console.log("dispatched (no command_id returned)");
+    return {
+      machineId,
+      ok: true,
+      message: `agent upgraded to ${observed}; cli.update dispatched`,
+    };
+  }
+
+  const result = await waitForCommandResult(machineId, commandId, 20_000);
+  if (!result) {
+    console.log("dispatched (result pending; see `seed fleet audit`)");
+    return {
+      machineId,
+      ok: true,
+      message: `agent upgraded to ${observed}; cli.update dispatched (result pending)`,
+    };
+  }
+  console.log(result.output ?? (result.success ? "ok" : "failed"));
   return {
     machineId,
-    ok: false,
-    message: `timeout; last observed version: ${observed ?? "none"}`,
+    ok: true,
+    message: `agent upgraded to ${observed}; ${result.output ?? (result.success ? "cli.update ok" : "cli.update failed")}`,
   };
+}
+
+/**
+ * Poll the audit log for a command_result matching `commandId`. Returns
+ * null on timeout. Used by cmdUpgrade to surface cli.update outcomes
+ * since the HTTP dispatch is fire-and-forget.
+ */
+async function waitForCommandResult(
+  machineId: string,
+  commandId: string,
+  timeoutMs: number
+): Promise<{ success: boolean; output?: string } | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 500));
+    try {
+      const entries = (await apiGet(
+        `/v1/audit?machine_id=${encodeURIComponent(machineId)}&limit=30`
+      )) as Array<{
+        command_id?: string;
+        action?: string;
+        result?: string;
+        details?: string;
+      }>;
+      const match = entries.find(
+        (e) => e.command_id === commandId && e.action === "command_result"
+      );
+      if (match) {
+        return {
+          success: match.result === "success",
+          output: match.details ?? undefined,
+        };
+      }
+    } catch {
+      // keep polling; transient errors are common during upgrades
+    }
+  }
+  return null;
 }
 
 async function cmdUpgrade(args: string[]) {

--- a/packages/fleet/control/src/types.ts
+++ b/packages/fleet/control/src/types.ts
@@ -407,6 +407,7 @@ export const ACTION_WHITELIST = [
   "repo.pull",
   "agent.update",
   "agent.restart",
+  "cli.update",
   "workload.install",
   "workload.reload",
   "workload.remove",

--- a/packages/fleet/control/src/version.ts
+++ b/packages/fleet/control/src/version.ts
@@ -7,7 +7,7 @@
  *
  * Bump this in lockstep with the `v*.*.*` tag used to cut a release.
  */
-export const SEED_VERSION = "0.4.3";
+export const SEED_VERSION = "0.4.4";
 
 /** GitHub repo that publishes releases (owner/name). */
 export const SEED_REPO = "phyter1/seed";


### PR DESCRIPTION
## Summary

- Adds `cli.update` WebSocket command to ACTION_WHITELIST + agent handler that calls `runSelfUpdate({binary: \"seed-cli\"})` against the CLI binary on the same machine.
- Extends `seed fleet upgrade` to dispatch `cli.update` after each agent reconnects at the new version.
- Polls the audit log for the command_result to surface the CLI update outcome in the upgrade summary.

## Why

Previously `seed fleet upgrade` only updated the agent binary. The CLI binary on fleet machines stayed stale, forcing operators to scp new binaries manually — violating the principle that binary distribution flows pull-from-GitHub, never push-via-SSH (see \`docs/GAPS-2026-04-05.md\` §1.6a).

Both binaries now propagate through the same GitHub release pull channel.

## Behavior

- Machines without a CLI installed report a skipping success (best-effort — a pure agent-only host is valid).
- CLI location detected via canonical paths: \`~/.local/bin/seed\`, \`~/.local/bin/seed-cli\`, \`/usr/local/bin/seed\`, \`/opt/homebrew/bin/seed\`.
- Current CLI version read by exec'ing the binary with \`version\`.
- cli.update failure does not fail the overall upgrade (agent success is the primary outcome).

## Test plan

- [x] 7 new tests for \`findCliPath\` + \`getCliVersion\` with various shell scripts as fake CLIs
- [x] All 232 fleet-control tests pass
- [x] Agent binary compiles + runs (\`--version\` outputs 0.4.4)
- [x] \`import.meta.main\` guard added to agent.ts so tests can import without triggering daemon startup