### PR TITLE
feat(workload-installer): GC old install dirs after successful install

### DIFF
--- a/packages/fleet/control/src/workload-installer.test.ts
+++ b/packages/fleet/control/src/workload-installer.test.ts
@@ -7,6 +7,8 @@ import {
   verifyInstalledChecksums,
   extractTarball,
   installWorkload,
+  pruneOldInstalls,
+  compareSemver,
 } from "./workload-installer";
 import type { WorkloadManifest, WorkloadDeclaration } from "./types";
 import type { SupervisorDriver } from "./supervisors/launchd";
@@ -280,5 +282,112 @@ describe("installWorkload (full flow with mock driver)", () => {
         logDir: join(tmp, "logs"),
       })
     ).rejects.toThrow(/unsupported artifact URL scheme/);
+  });
+});
+
+describe("compareSemver", () => {
+  test("orders patch versions numerically", () => {
+    expect(compareSemver("0.4.2", "0.4.10")).toBeLessThan(0);
+    expect(compareSemver("0.4.10", "0.4.2")).toBeGreaterThan(0);
+  });
+
+  test("orders minor and major versions", () => {
+    expect(compareSemver("0.5.0", "0.4.99")).toBeGreaterThan(0);
+    expect(compareSemver("1.0.0", "0.99.99")).toBeGreaterThan(0);
+  });
+
+  test("equal versions return 0", () => {
+    expect(compareSemver("1.2.3", "1.2.3")).toBe(0);
+  });
+
+  test("handles missing components as zero", () => {
+    expect(compareSemver("1", "1.0.0")).toBe(0);
+    expect(compareSemver("1.2", "1.2.0")).toBe(0);
+  });
+});
+
+describe("pruneOldInstalls", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "seed-prune-"));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  const seed = (names: string[]): void => {
+    for (const n of names) {
+      mkdirSync(join(root, n), { recursive: true });
+      writeFileSync(join(root, n, "marker"), "x");
+    }
+  };
+
+  test("keeps current + N prior, removes the rest", () => {
+    seed([
+      "memory-0.1.0",
+      "memory-0.2.0",
+      "memory-0.4.2",
+      "memory-0.4.8",
+      "memory-0.4.9",
+    ]);
+    const removed = pruneOldInstalls(root, "memory", "0.4.9", 1);
+    expect(removed.sort()).toEqual(
+      ["memory-0.1.0", "memory-0.2.0", "memory-0.4.2"].sort()
+    );
+    expect(existsSync(join(root, "memory-0.4.9"))).toBe(true);
+    expect(existsSync(join(root, "memory-0.4.8"))).toBe(true);
+    expect(existsSync(join(root, "memory-0.4.2"))).toBe(false);
+  });
+
+  test("keepPrior=0 removes every non-current version", () => {
+    seed(["memory-0.4.8", "memory-0.4.9"]);
+    const removed = pruneOldInstalls(root, "memory", "0.4.9", 0);
+    expect(removed).toEqual(["memory-0.4.8"]);
+    expect(existsSync(join(root, "memory-0.4.8"))).toBe(false);
+  });
+
+  test("keepPrior=-1 disables pruning", () => {
+    seed(["memory-0.1.0", "memory-0.4.8", "memory-0.4.9"]);
+    const removed = pruneOldInstalls(root, "memory", "0.4.9", -1);
+    expect(removed).toEqual([]);
+    expect(existsSync(join(root, "memory-0.1.0"))).toBe(true);
+  });
+
+  test("ignores dirs from other workloads", () => {
+    seed(["memory-0.4.9", "memory-0.4.8", "fleet-router-1.0.0", "fleet-router-0.3.0"]);
+    const removed = pruneOldInstalls(root, "memory", "0.4.9", 0);
+    expect(removed).toEqual(["memory-0.4.8"]);
+    expect(existsSync(join(root, "fleet-router-1.0.0"))).toBe(true);
+    expect(existsSync(join(root, "fleet-router-0.3.0"))).toBe(true);
+  });
+
+  test("no-op when no prior versions exist", () => {
+    seed(["memory-0.4.9"]);
+    const removed = pruneOldInstalls(root, "memory", "0.4.9", 1);
+    expect(removed).toEqual([]);
+  });
+
+  test("no-op on non-existent installRoot", () => {
+    rmSync(root, { recursive: true, force: true });
+    const removed = pruneOldInstalls(root, "memory", "0.4.9", 1);
+    expect(removed).toEqual([]);
+  });
+
+  test("ignores regular files matching the pattern", () => {
+    seed(["memory-0.4.8"]);
+    writeFileSync(join(root, "memory-0.4.7-darwin-x64.tar.gz"), "tarball");
+    const removed = pruneOldInstalls(root, "memory", "0.4.9", 0);
+    expect(removed).toEqual(["memory-0.4.8"]);
+    expect(existsSync(join(root, "memory-0.4.7-darwin-x64.tar.gz"))).toBe(true);
+  });
+
+  test("sorts by semver not lexical (multi-digit safe)", () => {
+    seed(["memory-0.4.2", "memory-0.4.10", "memory-0.4.9"]);
+    // current=0.4.10, keepPrior=1 → keep 0.4.9, drop 0.4.2
+    const removed = pruneOldInstalls(root, "memory", "0.4.10", 1);
+    expect(removed).toEqual(["memory-0.4.2"]);
+    expect(existsSync(join(root, "memory-0.4.9"))).toBe(true);
   });
 });

--- a/packages/fleet/control/src/workload-installer.ts
+++ b/packages/fleet/control/src/workload-installer.ts
@@ -8,7 +8,14 @@
  */
 
 import { createHash } from "node:crypto";
-import { readFileSync, writeFileSync, mkdirSync, existsSync, rmSync } from "node:fs";
+import {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  existsSync,
+  rmSync,
+  readdirSync,
+} from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import type {
   WorkloadManifest,
@@ -30,6 +37,10 @@ export interface InstallerOptions {
   /** Directory for workload stdout/stderr logs.
    *  Defaults to `~/Library/Logs`. */
   logDir?: string;
+  /** Number of prior install dirs (non-current) to retain after a
+   *  successful install, for rollback headroom. Defaults to 1.
+   *  Use 0 for aggressive GC, -1 to disable pruning entirely. */
+  keepPrior?: number;
 }
 
 export interface InstallResult {
@@ -108,6 +119,65 @@ export function verifyInstalledChecksums(
       );
     }
   }
+}
+
+/**
+ * Compare two semver strings numerically. Returns negative if a<b,
+ * positive if a>b, zero if equal. Unknown suffix characters after
+ * the major.minor.patch triple are compared lexically.
+ */
+export function compareSemver(a: string, b: string): number {
+  const parse = (s: string): number[] => {
+    const core = s.split(/[-+]/)[0];
+    return core.split(".").map((p) => Number(p) || 0);
+  };
+  const ap = parse(a);
+  const bp = parse(b);
+  const len = Math.max(ap.length, bp.length, 3);
+  for (let i = 0; i < len; i++) {
+    const diff = (ap[i] ?? 0) - (bp[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+/**
+ * Remove install dirs under `installRoot` matching the pattern
+ * `${workloadId}-*`, retaining the current version plus `keepPrior`
+ * most-recent non-current versions. Returns the list of removed dir
+ * names.
+ *
+ * Safe to call even when no prior installs exist. Passing keepPrior=-1
+ * disables pruning entirely. A non-existent installRoot is a no-op.
+ */
+export function pruneOldInstalls(
+  installRoot: string,
+  workloadId: string,
+  currentVersion: string,
+  keepPrior: number
+): string[] {
+  if (keepPrior < 0) return [];
+  if (!existsSync(installRoot)) return [];
+  const entries = readdirSync(installRoot, { withFileTypes: true });
+  const prefix = `${workloadId}-`;
+  const currentName = `${workloadId}-${currentVersion}`;
+
+  const prior = entries
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .filter((name) => name.startsWith(prefix) && name !== currentName)
+    .sort((a, b) => {
+      const va = a.slice(prefix.length);
+      const vb = b.slice(prefix.length);
+      // Descending: most-recent first.
+      return compareSemver(vb, va);
+    });
+
+  const toRemove = prior.slice(keepPrior);
+  for (const name of toRemove) {
+    rmSync(join(installRoot, name), { recursive: true, force: true });
+  }
+  return toRemove;
 }
 
 function homeDir(): string {
@@ -251,6 +321,22 @@ export async function installWorkload(
     last_probe_at: null,
     last_probe_tier: null,
   };
+
+  // 10. Prune older install dirs for this workload. Default keepPrior=1
+  //     leaves one rollback target. Runs only on the happy path so a
+  //     failed install never destroys working prior state.
+  const keepPrior = opts.keepPrior ?? 1;
+  const pruned = pruneOldInstalls(
+    installRoot,
+    manifest.id,
+    manifest.version,
+    keepPrior
+  );
+  if (pruned.length > 0) {
+    console.log(
+      `[installer] pruned ${pruned.length} prior install dir(s): ${pruned.join(", ")}`
+    );
+  }
 
   return { manifest, record, plistPath };
 }


### PR DESCRIPTION
## Summary

After a workload installs successfully, prior install dirs for the same workload are removed, retaining current + \`keepPrior\` most-recent (default 1).

## Why

ren1 was carrying ~500MB of dead memory install dirs (0.1.0, 0.2.0, 0.4.2–0.4.9 all present) because the installer never pruned. ~50MB per release, unbounded. GAPS §1.4(a).

## Behavior

- \`keepPrior\` option (default 1) — number of non-current prior versions to keep for rollback
- \`keepPrior: 0\` — aggressive GC, only current remains
- \`keepPrior: -1\` — disable pruning entirely
- Runs only on happy path; failed installs leave prior state intact
- Semver-aware comparison (0.4.10 > 0.4.9 > 0.4.2, not lexical)
- Ignores dirs from other workloads, ignores non-directory entries

## Scope

Only \`installRoot\` is pruned. \`workload-artifacts/\` staging and \`/tmp\` orphans (GAPS §1.4b, §1.4c) are separate — artifact URLs are operator input.

## Test plan

- [x] 12 new tests (4 compareSemver + 8 pruneOldInstalls)
- [x] 244 total fleet-control tests pass
- [x] Multi-digit version ordering verified
- [x] Other-workload isolation verified