### PR TITLE
docs(gaps): expand §1.4 with full workload cleanup audit

### DIFF
--- a/docs/GAPS-2026-04-05.md
+++ b/docs/GAPS-2026-04-05.md
@@ -47,17 +47,23 @@ Thorough accounting of current gaps, carried-forward follow-ups from recent hand
 
 ---
 
-### 1.4 Phase 1 workload installer — no garbage collection
+### 1.4 Workload installer — three distinct cleanup gaps
 
-**Where:** `packages/fleet/` workload installer.
+**Audited 2026-04-05:** ren1 is carrying **~838MB of dead seed state** from accumulated workload upgrades. At current release cadence (~10 memory releases in 24h), this grows by ~74MB per release, unbounded.
 
-**Problem:** On ren1, old memory install dirs pile up — currently `memory-0.1.0/`, `memory-0.2.0/`, `memory-0.4.2/` through `memory-0.4.8/` all remain after upgrade to 0.4.9.
+**Three distinct gaps:**
 
-**Impact:** Disk creep on fleet machines. Ambiguity about which version is actually live. No automated rollback target selection.
+**(a) Install-dir GC missing.** After `workload.install memory-0.4.9`, the previous `memory-0.4.8/` install dir isn't removed. ren1 currently holds 10 memory install dirs: `0.1.0, 0.2.0, 0.4.2, 0.4.3, 0.4.4, 0.4.5, 0.4.6, 0.4.7, 0.4.8, 0.4.9` — ~500MB. ren3 holds 2 fleet-router install dirs. Fix: installer should remove prior install dirs not matching `current + N previous` after a successful install. N should be configurable (suggest N=2 for rollback headroom).
 
-**Fix:** Installer should GC install dirs not matching current + N previous versions.
+**(b) Artifact staging never purged.** Tarballs download to `~/.local/share/seed/workload-artifacts/` (e.g. `memory-0.4.9-darwin-x64.tar.gz`), get extracted into `~/.local/share/seed/workloads/`, and then sit there forever. ren1 holds 8 stale artifact tarballs (0.4.2–0.4.9) at 24MB each = 192MB. Fix: delete the tarball after successful extraction, OR keep only the N most-recent matching the GC'd install-dir policy.
 
-**Source:** `HANDOFF-memory-search-and-recall-skill-2026-04-05.md` quirk, also in prior handoffs.
+**(c) Bootstrap `/tmp` orphans.** ren1 has `/tmp/memory-0.1.0-darwin-x64.tar.gz`, `/tmp/memory-0.2.0-darwin-x64.tar.gz`, and `/tmp/seed-memory-seed.db` — dating to initial bootstrap from Apr 4. ~57MB. Never cleaned up by any automated path. Fix: early installer drafts used `/tmp` as staging; newer flow uses `workload-artifacts/`. Installer should sweep stale seed-owned `/tmp` files on startup, OR these are one-shot cleanup the operator runs once.
+
+**Binary self-update is clean** — atomic-rename replace works correctly; zero orphan `.new.PID` or `.tmp` files across ren1/ren2/ren3. Only workload state accumulates.
+
+**Installer launchd re-bootstrap gap** from prior handoffs (see §1.3) is a related but distinct issue.
+
+**Source:** `HANDOFF-memory-search-and-recall-skill-2026-04-05.md` quirk, plus audit 2026-04-05.
 
 ---
 


### PR DESCRIPTION
Expands GAPS §1.4 with the 2026-04-05 audit findings: 3 distinct workload cleanup gaps with specific disk-usage numbers, note that binary self-update is clean. Matches the install-dir GC fix in #22.