### PR TITLE
feat(fleet): seed fleet workload gc — retro-cleanup of stale workload state

### DIFF
--- a/packages/fleet/control/src/agent.ts
+++ b/packages/fleet/control/src/agent.ts
@@ -41,6 +41,7 @@ import {
   reconcile as reconcileWorkloads,
   type ReconcileSummary,
 } from "./workload-runner";
+import { gcWorkload, type GcWorkloadReport } from "./workload-installer";
 import type { WorkloadDeclaration } from "./types";
 
 function summarizeReconcile(s: ReconcileSummary): string {
@@ -905,6 +906,54 @@ async function runAgent() {
         workloadDb.updateState(workloadId, "install_failed", err?.message ?? String(err));
         return { success: false, output: err?.message ?? String(err) };
       }
+    });
+
+    commandHandlers.set("workload.gc", async (params) => {
+      const targetId = params.workload_id as string | undefined;
+      const keepPrior =
+        typeof params.keep_prior === "number"
+          ? (params.keep_prior as number)
+          : 1;
+      const includeTmp = params.include_tmp === true;
+      const dryRun = params.dry_run === true;
+
+      // Determine which workload IDs to GC. If targetId is given, do
+      // just that one (even if no record exists — there may still be
+      // orphaned install-dirs/artifacts for it). Otherwise, union the
+      // declared workloads with whatever the DB knows about, so we
+      // catch removed-but-not-cleaned-up workloads too.
+      const declared = (cachedConfig?.workloads ?? []) as WorkloadDeclaration[];
+      const knownIds = new Set<string>();
+      if (targetId) {
+        knownIds.add(targetId);
+      } else {
+        for (const d of declared) knownIds.add(d.id);
+        for (const r of workloadDb.list()) knownIds.add(r.workload_id);
+      }
+
+      const reports: GcWorkloadReport[] = [];
+      for (const id of knownIds) {
+        const record = workloadDb.get(id);
+        const currentVersion = record?.version ?? null;
+        reports.push(
+          gcWorkload(id, currentVersion, { keepPrior, includeTmp, dryRun })
+        );
+      }
+
+      const totalBytesFreed = reports.reduce(
+        (sum, r) => sum + r.bytesFreed,
+        0
+      );
+      return {
+        success: true,
+        output: JSON.stringify({
+          dry_run: dryRun,
+          keep_prior: keepPrior,
+          include_tmp: includeTmp,
+          total_bytes_freed: totalBytesFreed,
+          workloads: reports,
+        }),
+      };
     });
 
     commandHandlers.set("workload.remove", async (params) => {

--- a/packages/fleet/control/src/cli.ts
+++ b/packages/fleet/control/src/cli.ts
@@ -918,6 +918,198 @@ async function cmdUpgrade(args: string[]) {
   if (failed.length > 0) process.exit(1);
 }
 
+// --- Workload GC ---
+
+interface WorkloadGcArgs {
+  machineId: string;
+  workloadId?: string;
+  keepPrior: number;
+  includeTmp: boolean;
+  dryRun: boolean;
+}
+
+function parseWorkloadGcArgs(args: string[]): WorkloadGcArgs {
+  let machineId: string | undefined;
+  let workloadId: string | undefined;
+  let keepPrior = 1;
+  let includeTmp = false;
+  let dryRun = false;
+
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--machine" && args[i + 1]) machineId = args[++i];
+    else if (a === "--workload" && args[i + 1]) workloadId = args[++i];
+    else if (a === "--keep-prior" && args[i + 1]) {
+      const n = parseInt(args[++i], 10);
+      if (Number.isNaN(n)) {
+        console.error("--keep-prior must be an integer");
+        process.exit(1);
+      }
+      keepPrior = n;
+    } else if (a === "--include-tmp") includeTmp = true;
+    else if (a === "--dry-run") dryRun = true;
+    else {
+      console.error(`Unknown argument: ${a}`);
+      console.error(
+        "Usage: seed fleet workload gc --machine <id> [--workload <id>] [--keep-prior N] [--include-tmp] [--dry-run]"
+      );
+      process.exit(1);
+    }
+  }
+
+  if (!machineId) {
+    console.error("--machine <id> is required");
+    console.error(
+      "Usage: seed fleet workload gc --machine <id> [--workload <id>] [--keep-prior N] [--include-tmp] [--dry-run]"
+    );
+    process.exit(1);
+  }
+
+  return { machineId, workloadId, keepPrior, includeTmp, dryRun };
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  const kb = n / 1024;
+  if (kb < 1024) return `${kb.toFixed(1)} KB`;
+  const mb = kb / 1024;
+  if (mb < 1024) return `${mb.toFixed(1)} MB`;
+  return `${(mb / 1024).toFixed(2)} GB`;
+}
+
+interface WorkloadGcReportPayload {
+  dry_run: boolean;
+  keep_prior: number;
+  include_tmp: boolean;
+  total_bytes_freed: number;
+  workloads: Array<{
+    workloadId: string;
+    currentVersion: string | null;
+    installDirs: { removed: string[]; bytesFreed: number };
+    artifacts: { removed: string[]; bytesFreed: number };
+    tmpOrphans: { removed: string[]; bytesFreed: number };
+    bytesFreed: number;
+  }>;
+}
+
+function printWorkloadGcReport(
+  machineId: string,
+  report: WorkloadGcReportPayload
+): void {
+  const mode = report.dry_run ? "dry-run" : "applied";
+  console.log("");
+  console.log(
+    `${machineId}: workload gc [${mode}] (keep-prior=${report.keep_prior}, include-tmp=${report.include_tmp})`
+  );
+
+  if (report.workloads.length === 0) {
+    console.log("  (no workloads found)");
+    return;
+  }
+
+  for (const w of report.workloads) {
+    const current = w.currentVersion ?? "(not installed)";
+    console.log(`  ${w.workloadId} — current: ${current}`);
+    const sections: Array<[string, { removed: string[]; bytesFreed: number }]> = [
+      ["install-dirs", w.installDirs],
+      ["artifacts", w.artifacts],
+      ["tmp orphans", w.tmpOrphans],
+    ];
+    let anyActivity = false;
+    for (const [label, section] of sections) {
+      if (section.removed.length === 0) continue;
+      anyActivity = true;
+      console.log(
+        `    ${label} (${section.removed.length}, ${formatBytes(section.bytesFreed)}):`
+      );
+      for (const name of section.removed) console.log(`      - ${name}`);
+    }
+    if (!anyActivity) {
+      console.log("    nothing to remove");
+    } else {
+      console.log(`    subtotal: ${formatBytes(w.bytesFreed)}`);
+    }
+  }
+
+  console.log("");
+  console.log(`Total freed: ${formatBytes(report.total_bytes_freed)}`);
+  if (report.dry_run) {
+    console.log("(dry-run: no files were deleted. Re-run without --dry-run to apply.)");
+  }
+}
+
+async function cmdWorkloadGc(args: string[]) {
+  const opts = parseWorkloadGcArgs(args);
+
+  const params: Record<string, unknown> = {
+    keep_prior: opts.keepPrior,
+    include_tmp: opts.includeTmp,
+    dry_run: opts.dryRun,
+  };
+  if (opts.workloadId) params.workload_id = opts.workloadId;
+
+  process.stdout.write(
+    `  ${opts.machineId}: dispatching workload.gc${opts.workloadId ? ` (${opts.workloadId})` : ""}... `
+  );
+  let dispatch: { command_id?: string };
+  try {
+    dispatch = (await apiPost(`/v1/fleet/${opts.machineId}/command`, {
+      action: "workload.gc",
+      params,
+      timeout_ms: 60_000,
+    })) as { command_id?: string };
+  } catch (err: any) {
+    console.log(`FAIL (${err?.message ?? err})`);
+    process.exit(1);
+  }
+
+  const commandId = dispatch.command_id;
+  if (!commandId) {
+    console.log("dispatched (no command_id; check `seed fleet audit`)");
+    return;
+  }
+
+  console.log("dispatched. waiting for result...");
+  const result = await waitForCommandResult(opts.machineId, commandId, 60_000);
+  if (!result) {
+    console.log("  result pending — re-check with: seed fleet audit --limit 10");
+    return;
+  }
+
+  if (!result.success) {
+    console.log(`  ✗ ${result.output ?? "workload.gc failed"}`);
+    process.exit(1);
+  }
+
+  let payload: WorkloadGcReportPayload;
+  try {
+    payload = JSON.parse(result.output ?? "{}") as WorkloadGcReportPayload;
+  } catch (err: any) {
+    console.log(`  ✓ ok, but couldn't parse report: ${result.output ?? ""}`);
+    return;
+  }
+  printWorkloadGcReport(opts.machineId, payload);
+}
+
+async function cmdWorkload(args: string[]) {
+  const sub = args[0];
+  switch (sub) {
+    case "gc":
+      await cmdWorkloadGc(args.slice(1));
+      break;
+    default:
+      console.error("Usage: seed fleet workload <subcommand>");
+      console.error("");
+      console.error("Subcommands:");
+      console.error(
+        "  gc --machine <id> [--workload <id>] [--keep-prior N] [--include-tmp] [--dry-run]"
+      );
+      console.error("     Garbage-collect old install-dirs, stale artifact");
+      console.error("     tarballs, and (opt-in) /tmp bootstrap orphans");
+      process.exit(sub ? 1 : 0);
+  }
+}
+
 // --- Control-plane update ---
 
 async function cmdUpgradeControlPlane(args: string[]) {
@@ -1359,6 +1551,10 @@ async function main() {
       await cmdInstalls(args.slice(1));
       break;
 
+    case "workload":
+      await cmdWorkload(args.slice(1));
+      break;
+
     case "audit": {
       let limit = 100;
       const limitIdx = args.indexOf("--limit");
@@ -1402,6 +1598,14 @@ async function main() {
         "  installs [<install_id>] [--status S] [--follow] [--events]"
       );
       console.log("                      Observe install sessions");
+      console.log(
+        "  workload gc --machine <id> [--workload <id>] [--keep-prior N]"
+      );
+      console.log("              [--include-tmp] [--dry-run]");
+      console.log(
+        "                      Clean up old install-dirs, stale artifact"
+      );
+      console.log("                      tarballs, and /tmp bootstrap orphans");
       console.log(
         "  join <url> [--machine-id <id>] [--display-name <name>]  Register this machine with a control plane"
       );

--- a/packages/fleet/control/src/types.ts
+++ b/packages/fleet/control/src/types.ts
@@ -414,6 +414,7 @@ export const ACTION_WHITELIST = [
   "workload.remove",
   "workload.status",
   "workload.reconcile",
+  "workload.gc",
 ] as const;
 
 export type ActionName = (typeof ACTION_WHITELIST)[number];

--- a/packages/fleet/control/src/workload-installer.test.ts
+++ b/packages/fleet/control/src/workload-installer.test.ts
@@ -9,6 +9,11 @@ import {
   installWorkload,
   pruneOldInstalls,
   compareSemver,
+  pathSize,
+  parseArtifactVersion,
+  pruneArtifactTarballs,
+  sweepTmpOrphans,
+  gcWorkload,
 } from "./workload-installer";
 import type { WorkloadManifest, WorkloadDeclaration } from "./types";
 import type { SupervisorDriver } from "./supervisors/launchd";
@@ -389,5 +394,371 @@ describe("pruneOldInstalls", () => {
     const removed = pruneOldInstalls(root, "memory", "0.4.10", 1);
     expect(removed).toEqual(["memory-0.4.2"]);
     expect(existsSync(join(root, "memory-0.4.9"))).toBe(true);
+  });
+});
+
+describe("pathSize", () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "seed-size-"));
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("returns 0 for missing path", () => {
+    expect(pathSize(join(root, "nope"))).toBe(0);
+  });
+
+  test("returns byte size of a single file", () => {
+    const f = join(root, "x.txt");
+    writeFileSync(f, "hello world"); // 11 bytes
+    expect(pathSize(f)).toBe(11);
+  });
+
+  test("sums file sizes recursively", () => {
+    mkdirSync(join(root, "a/b"), { recursive: true });
+    writeFileSync(join(root, "top.txt"), "1234"); // 4
+    writeFileSync(join(root, "a/mid.txt"), "abcdef"); // 6
+    writeFileSync(join(root, "a/b/deep.txt"), "z"); // 1
+    expect(pathSize(root)).toBe(11);
+  });
+});
+
+describe("parseArtifactVersion", () => {
+  test("extracts version from well-formed artifact name", () => {
+    expect(parseArtifactVersion("memory-0.4.9-darwin-x64.tar.gz", "memory"))
+      .toBe("0.4.9");
+    expect(parseArtifactVersion("memory-0.4.10-linux-x64.tar.gz", "memory"))
+      .toBe("0.4.10");
+    expect(parseArtifactVersion("memory-0.4.9-rc1-darwin-arm64.tar.gz", "memory"))
+      .toBe("0.4.9-rc1");
+  });
+
+  test("returns null for non-matching names", () => {
+    expect(parseArtifactVersion("memory-0.4.9.tar.gz", "memory")).toBe(null);
+    expect(parseArtifactVersion("memory-darwin-x64.tar.gz", "memory")).toBe(null);
+    expect(parseArtifactVersion("other-0.4.9-darwin-x64.tar.gz", "memory")).toBe(null);
+    expect(parseArtifactVersion("memory-0.4.9-darwin-x64.zip", "memory")).toBe(null);
+  });
+
+  test("workloadId must match prefix exactly", () => {
+    expect(parseArtifactVersion("memory-service-0.4.9-darwin-x64.tar.gz", "memory"))
+      .toBe(null);
+  });
+});
+
+describe("pruneArtifactTarballs", () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "seed-artifacts-"));
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  const seedTarballs = (names: string[]): void => {
+    for (const n of names) writeFileSync(join(root, n), "tarball-contents");
+  };
+
+  test("removes tarballs whose version is not retained", () => {
+    seedTarballs([
+      "memory-0.4.2-darwin-x64.tar.gz",
+      "memory-0.4.8-darwin-x64.tar.gz",
+      "memory-0.4.9-darwin-x64.tar.gz",
+    ]);
+    const { removed, bytesFreed } = pruneArtifactTarballs(
+      root,
+      "memory",
+      new Set(["0.4.9"]),
+      false
+    );
+    expect(removed.sort()).toEqual([
+      "memory-0.4.2-darwin-x64.tar.gz",
+      "memory-0.4.8-darwin-x64.tar.gz",
+    ]);
+    expect(bytesFreed).toBeGreaterThan(0);
+    expect(existsSync(join(root, "memory-0.4.9-darwin-x64.tar.gz"))).toBe(true);
+    expect(existsSync(join(root, "memory-0.4.8-darwin-x64.tar.gz"))).toBe(false);
+  });
+
+  test("dryRun reports without deleting", () => {
+    seedTarballs(["memory-0.4.2-darwin-x64.tar.gz", "memory-0.4.9-darwin-x64.tar.gz"]);
+    const { removed } = pruneArtifactTarballs(
+      root,
+      "memory",
+      new Set(["0.4.9"]),
+      true
+    );
+    expect(removed).toEqual(["memory-0.4.2-darwin-x64.tar.gz"]);
+    expect(existsSync(join(root, "memory-0.4.2-darwin-x64.tar.gz"))).toBe(true);
+  });
+
+  test("ignores files for other workloads", () => {
+    seedTarballs([
+      "memory-0.4.2-darwin-x64.tar.gz",
+      "fleet-router-0.4.2-darwin-x64.tar.gz",
+    ]);
+    const { removed } = pruneArtifactTarballs(
+      root,
+      "memory",
+      new Set(["0.4.9"]),
+      false
+    );
+    expect(removed).toEqual(["memory-0.4.2-darwin-x64.tar.gz"]);
+    expect(existsSync(join(root, "fleet-router-0.4.2-darwin-x64.tar.gz"))).toBe(true);
+  });
+
+  test("ignores unrelated files in artifact root", () => {
+    seedTarballs(["memory-0.4.2-darwin-x64.tar.gz"]);
+    writeFileSync(join(root, "README.md"), "docs");
+    writeFileSync(join(root, "memory-latest.txt"), "pointer");
+    const { removed } = pruneArtifactTarballs(
+      root,
+      "memory",
+      new Set(),
+      false
+    );
+    expect(removed).toEqual(["memory-0.4.2-darwin-x64.tar.gz"]);
+    expect(existsSync(join(root, "README.md"))).toBe(true);
+    expect(existsSync(join(root, "memory-latest.txt"))).toBe(true);
+  });
+
+  test("no-op on non-existent root", () => {
+    rmSync(root, { recursive: true, force: true });
+    const { removed, bytesFreed } = pruneArtifactTarballs(
+      root,
+      "memory",
+      new Set(),
+      false
+    );
+    expect(removed).toEqual([]);
+    expect(bytesFreed).toBe(0);
+  });
+});
+
+describe("sweepTmpOrphans", () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "seed-tmp-"));
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("removes semver-shaped tarballs and seed-owned dbs", () => {
+    writeFileSync(join(root, "memory-0.1.0-darwin-x64.tar.gz"), "old");
+    writeFileSync(join(root, "memory-0.2.0-darwin-x64.tar.gz"), "older");
+    writeFileSync(join(root, "seed-memory-seed.db"), "db");
+    writeFileSync(join(root, "seed-memory-seed.db-wal"), "wal");
+    const { removed } = sweepTmpOrphans(root, "memory", false);
+    expect(removed.sort()).toEqual(
+      [
+        "memory-0.1.0-darwin-x64.tar.gz",
+        "memory-0.2.0-darwin-x64.tar.gz",
+        "seed-memory-seed.db",
+        "seed-memory-seed.db-wal",
+      ].sort()
+    );
+  });
+
+  test("does not touch unrelated files", () => {
+    writeFileSync(join(root, "user-notes.txt"), "mine");
+    writeFileSync(join(root, "memory-thoughts.txt"), "mine too"); // no semver
+    writeFileSync(join(root, "memory.tar.gz"), "archive"); // no version
+    writeFileSync(join(root, "seed-other-seed.db"), "wrong workload");
+    const { removed } = sweepTmpOrphans(root, "memory", false);
+    expect(removed).toEqual([]);
+    expect(existsSync(join(root, "user-notes.txt"))).toBe(true);
+    expect(existsSync(join(root, "memory-thoughts.txt"))).toBe(true);
+    expect(existsSync(join(root, "seed-other-seed.db"))).toBe(true);
+  });
+
+  test("dryRun reports without deleting", () => {
+    writeFileSync(join(root, "memory-0.1.0-darwin-x64.tar.gz"), "contents");
+    const { removed } = sweepTmpOrphans(root, "memory", true);
+    expect(removed).toEqual(["memory-0.1.0-darwin-x64.tar.gz"]);
+    expect(existsSync(join(root, "memory-0.1.0-darwin-x64.tar.gz"))).toBe(true);
+  });
+
+  test("no-op on non-existent root", () => {
+    rmSync(root, { recursive: true, force: true });
+    const { removed } = sweepTmpOrphans(root, "memory", false);
+    expect(removed).toEqual([]);
+  });
+});
+
+describe("gcWorkload", () => {
+  let root: string;
+  let installRoot: string;
+  let artifactRoot: string;
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "seed-gc-"));
+    installRoot = join(root, "workloads");
+    artifactRoot = join(root, "artifacts");
+    tmpRoot = join(root, "tmp");
+    mkdirSync(installRoot, { recursive: true });
+    mkdirSync(artifactRoot, { recursive: true });
+    mkdirSync(tmpRoot, { recursive: true });
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  const seedInstallDirs = (names: string[]) => {
+    for (const n of names) {
+      mkdirSync(join(installRoot, n), { recursive: true });
+      writeFileSync(join(installRoot, n, "marker"), "data-data");
+    }
+  };
+
+  test("retains current + keepPrior, removes older install-dirs and matching artifacts", () => {
+    seedInstallDirs([
+      "memory-0.4.2",
+      "memory-0.4.7",
+      "memory-0.4.8",
+      "memory-0.4.9",
+    ]);
+    for (const v of ["0.4.2", "0.4.7", "0.4.8", "0.4.9"]) {
+      writeFileSync(
+        join(artifactRoot, `memory-${v}-darwin-x64.tar.gz`),
+        "tarball-contents"
+      );
+    }
+
+    const report = gcWorkload("memory", "0.4.9", {
+      installRoot,
+      artifactRoot,
+      tmpRoot,
+      keepPrior: 1,
+      dryRun: false,
+    });
+
+    expect(report.installDirs.removed.sort()).toEqual([
+      "memory-0.4.2",
+      "memory-0.4.7",
+    ]);
+    expect(report.artifacts.removed.sort()).toEqual([
+      "memory-0.4.2-darwin-x64.tar.gz",
+      "memory-0.4.7-darwin-x64.tar.gz",
+    ]);
+    // Current + 1 prior retained:
+    expect(existsSync(join(installRoot, "memory-0.4.9"))).toBe(true);
+    expect(existsSync(join(installRoot, "memory-0.4.8"))).toBe(true);
+    expect(existsSync(join(installRoot, "memory-0.4.7"))).toBe(false);
+    // Retained install-dirs' artifacts stay:
+    expect(existsSync(join(artifactRoot, "memory-0.4.9-darwin-x64.tar.gz"))).toBe(true);
+    expect(existsSync(join(artifactRoot, "memory-0.4.8-darwin-x64.tar.gz"))).toBe(true);
+    // bytesFreed accounts for both:
+    expect(report.bytesFreed).toBeGreaterThan(0);
+    expect(report.bytesFreed).toBe(
+      report.installDirs.bytesFreed + report.artifacts.bytesFreed
+    );
+  });
+
+  test("keepPrior=0 removes every non-current version", () => {
+    seedInstallDirs(["memory-0.4.8", "memory-0.4.9"]);
+    const report = gcWorkload("memory", "0.4.9", {
+      installRoot,
+      artifactRoot,
+      tmpRoot,
+      keepPrior: 0,
+      dryRun: false,
+    });
+    expect(report.installDirs.removed).toEqual(["memory-0.4.8"]);
+    expect(existsSync(join(installRoot, "memory-0.4.9"))).toBe(true);
+  });
+
+  test("dryRun reports intended removals without touching disk", () => {
+    seedInstallDirs(["memory-0.4.8", "memory-0.4.9"]);
+    const report = gcWorkload("memory", "0.4.9", {
+      installRoot,
+      artifactRoot,
+      tmpRoot,
+      keepPrior: 0,
+      dryRun: true,
+    });
+    expect(report.installDirs.removed).toEqual(["memory-0.4.8"]);
+    expect(existsSync(join(installRoot, "memory-0.4.8"))).toBe(true);
+    expect(report.installDirs.bytesFreed).toBeGreaterThan(0);
+  });
+
+  test("currentVersion=null treats every install-dir as stale (keepPrior retains N most recent)", () => {
+    seedInstallDirs(["memory-0.4.7", "memory-0.4.8", "memory-0.4.9"]);
+    const report = gcWorkload("memory", null, {
+      installRoot,
+      artifactRoot,
+      tmpRoot,
+      keepPrior: 1,
+      dryRun: false,
+    });
+    // keepPrior=1 + no current = keep the single most-recent version
+    expect(report.installDirs.removed.sort()).toEqual([
+      "memory-0.4.7",
+      "memory-0.4.8",
+    ]);
+    expect(existsSync(join(installRoot, "memory-0.4.9"))).toBe(true);
+  });
+
+  test("keepPrior=-1 retains everything", () => {
+    seedInstallDirs(["memory-0.4.2", "memory-0.4.8", "memory-0.4.9"]);
+    const report = gcWorkload("memory", "0.4.9", {
+      installRoot,
+      artifactRoot,
+      tmpRoot,
+      keepPrior: -1,
+      dryRun: false,
+    });
+    expect(report.installDirs.removed).toEqual([]);
+    expect(existsSync(join(installRoot, "memory-0.4.2"))).toBe(true);
+  });
+
+  test("includeTmp=true sweeps tmp orphans", () => {
+    seedInstallDirs(["memory-0.4.9"]);
+    writeFileSync(join(tmpRoot, "memory-0.1.0-darwin-x64.tar.gz"), "old");
+    writeFileSync(join(tmpRoot, "seed-memory-seed.db"), "db");
+    const report = gcWorkload("memory", "0.4.9", {
+      installRoot,
+      artifactRoot,
+      tmpRoot,
+      keepPrior: 1,
+      includeTmp: true,
+      dryRun: false,
+    });
+    expect(report.tmpOrphans.removed.sort()).toEqual([
+      "memory-0.1.0-darwin-x64.tar.gz",
+      "seed-memory-seed.db",
+    ]);
+  });
+
+  test("includeTmp=false (default) leaves tmp alone", () => {
+    seedInstallDirs(["memory-0.4.9"]);
+    writeFileSync(join(tmpRoot, "memory-0.1.0-darwin-x64.tar.gz"), "old");
+    const report = gcWorkload("memory", "0.4.9", {
+      installRoot,
+      artifactRoot,
+      tmpRoot,
+      keepPrior: 1,
+      dryRun: false,
+    });
+    expect(report.tmpOrphans.removed).toEqual([]);
+    expect(existsSync(join(tmpRoot, "memory-0.1.0-darwin-x64.tar.gz"))).toBe(true);
+  });
+
+  test("no-op when nothing to clean", () => {
+    seedInstallDirs(["memory-0.4.9"]);
+    const report = gcWorkload("memory", "0.4.9", {
+      installRoot,
+      artifactRoot,
+      tmpRoot,
+      keepPrior: 1,
+      dryRun: false,
+    });
+    expect(report.installDirs.removed).toEqual([]);
+    expect(report.artifacts.removed).toEqual([]);
+    expect(report.tmpOrphans.removed).toEqual([]);
+    expect(report.bytesFreed).toBe(0);
   });
 });

--- a/packages/fleet/control/src/workload-installer.ts
+++ b/packages/fleet/control/src/workload-installer.ts
@@ -15,6 +15,7 @@ import {
   existsSync,
   rmSync,
   readdirSync,
+  statSync,
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import type {
@@ -180,6 +181,270 @@ export function pruneOldInstalls(
   return toRemove;
 }
 
+/**
+ * Recursively compute the total byte size of a file or directory tree.
+ * Follows no symlinks, tolerates missing paths (returns 0), and does
+ * not descend into paths it cannot stat.
+ */
+export function pathSize(p: string): number {
+  if (!existsSync(p)) return 0;
+  let total = 0;
+  const stack = [p];
+  while (stack.length > 0) {
+    const cur = stack.pop()!;
+    let st;
+    try {
+      st = statSync(cur);
+    } catch {
+      continue;
+    }
+    if (st.isDirectory()) {
+      let entries: string[];
+      try {
+        entries = readdirSync(cur);
+      } catch {
+        continue;
+      }
+      for (const e of entries) stack.push(join(cur, e));
+    } else if (st.isFile()) {
+      total += st.size;
+    }
+  }
+  return total;
+}
+
+/**
+ * Extract the semver version from a workload artifact tarball filename.
+ * Expected shape: `${workloadId}-${version}-${platform}-${arch}.tar.gz`.
+ * Returns null if the name doesn't match that shape.
+ */
+export function parseArtifactVersion(
+  name: string,
+  workloadId: string
+): string | null {
+  const prefix = `${workloadId}-`;
+  if (!name.startsWith(prefix) || !name.endsWith(".tar.gz")) return null;
+  const middle = name.slice(prefix.length, -".tar.gz".length);
+  // Match leading semver (e.g. "0.4.9" or "0.4.9-rc1") followed by -<platform>-<arch>
+  const m = middle.match(/^(\d+\.\d+\.\d+(?:[-+][\w.]+)?)-[\w.]+-[\w.]+$/);
+  return m ? m[1] : null;
+}
+
+/**
+ * Prune stale pre-staged artifact tarballs from `artifactRoot`, keeping
+ * only those whose version is in `retainVersions`. Returns the list of
+ * removed filenames. Non-existent `artifactRoot` is a no-op.
+ *
+ * Matches files shaped like `${workloadId}-${semver}-${platform}-${arch}.tar.gz`.
+ * Files that don't match this shape are ignored — they belong to
+ * something else.
+ */
+export function pruneArtifactTarballs(
+  artifactRoot: string,
+  workloadId: string,
+  retainVersions: Set<string>,
+  dryRun: boolean
+): { removed: string[]; bytesFreed: number } {
+  if (!existsSync(artifactRoot)) return { removed: [], bytesFreed: 0 };
+  const removed: string[] = [];
+  let bytesFreed = 0;
+  for (const entry of readdirSync(artifactRoot, { withFileTypes: true })) {
+    if (!entry.isFile()) continue;
+    const version = parseArtifactVersion(entry.name, workloadId);
+    if (version === null) continue;
+    if (retainVersions.has(version)) continue;
+    const full = join(artifactRoot, entry.name);
+    bytesFreed += pathSize(full);
+    if (!dryRun) rmSync(full, { force: true });
+    removed.push(entry.name);
+  }
+  return { removed, bytesFreed };
+}
+
+/**
+ * Sweep pre-v0.4 bootstrap debris from `/tmp` (or `tmpRoot`): tarballs
+ * shaped like `${workloadId}-${semver}-*.tar.gz` and seed-owned sqlite
+ * files shaped like `seed-${workloadId}-*.db` / `seed-${workloadId}-*.db-shm`
+ * / `seed-${workloadId}-*.db-wal`.
+ *
+ * Conservative — only matches files whose name starts with an expected
+ * prefix AND encodes a semver, so normal user files aren't caught.
+ * Opt-in via the GC caller (includeTmp flag).
+ */
+export function sweepTmpOrphans(
+  tmpRoot: string,
+  workloadId: string,
+  dryRun: boolean
+): { removed: string[]; bytesFreed: number } {
+  if (!existsSync(tmpRoot)) return { removed: [], bytesFreed: 0 };
+  const removed: string[] = [];
+  let bytesFreed = 0;
+  const tarPrefix = `${workloadId}-`;
+  const dbPrefix = `seed-${workloadId}-`;
+  const tarRegex = /^\d+\.\d+\.\d+(?:[-+][\w.]+)?-[\w.]+-[\w.]+\.tar\.gz$/;
+  const dbRegex = /^[\w.-]+\.db(-shm|-wal)?$/;
+  for (const entry of readdirSync(tmpRoot, { withFileTypes: true })) {
+    if (!entry.isFile()) continue;
+    let matches = false;
+    if (entry.name.startsWith(tarPrefix)) {
+      matches = tarRegex.test(entry.name.slice(tarPrefix.length));
+    } else if (entry.name.startsWith(dbPrefix)) {
+      matches = dbRegex.test(entry.name.slice(dbPrefix.length));
+    }
+    if (!matches) continue;
+    const full = join(tmpRoot, entry.name);
+    bytesFreed += pathSize(full);
+    if (!dryRun) rmSync(full, { force: true });
+    removed.push(entry.name);
+  }
+  return { removed, bytesFreed };
+}
+
+export interface GcWorkloadReport {
+  workloadId: string;
+  currentVersion: string | null;
+  installDirs: { removed: string[]; bytesFreed: number };
+  artifacts: { removed: string[]; bytesFreed: number };
+  tmpOrphans: { removed: string[]; bytesFreed: number };
+  bytesFreed: number;
+}
+
+export interface GcOptions {
+  /** Root directory for workload installs. Defaults to
+   *  `~/.local/share/seed/workloads`. */
+  installRoot?: string;
+  /** Root directory where pre-staged artifact tarballs live. Defaults
+   *  to `~/.local/share/seed/workload-artifacts`. */
+  artifactRoot?: string;
+  /** Directory to sweep for /tmp orphans. Defaults to `/tmp`. Only
+   *  swept when `includeTmp=true`. */
+  tmpRoot?: string;
+  /** Number of non-current install-dir versions to retain. Mirrors
+   *  InstallerOptions.keepPrior. Defaults to 1. */
+  keepPrior?: number;
+  /** If true, also sweep pre-v0.4 bootstrap debris from tmpRoot. */
+  includeTmp?: boolean;
+  /** If true, compute the report but remove nothing. */
+  dryRun?: boolean;
+}
+
+/**
+ * Garbage-collect on-disk workload state for a single workload:
+ *
+ *  1. Prune install-dirs under installRoot, keeping current + keepPrior.
+ *  2. Prune pre-staged artifact tarballs that don't match a retained
+ *     install-dir version.
+ *  3. (Opt-in) Sweep pre-v0.4 bootstrap debris from tmpRoot.
+ *
+ * `currentVersion` is the installed version per the caller's workload
+ * DB. If null, every install-dir for this workload is treated as
+ * stale (the workload is not installed here). dryRun reports what
+ * would be removed without touching disk.
+ */
+export function gcWorkload(
+  workloadId: string,
+  currentVersion: string | null,
+  opts: GcOptions = {}
+): GcWorkloadReport {
+  const installRoot = opts.installRoot ?? defaultInstallRoot();
+  const artifactRoot = opts.artifactRoot ?? defaultArtifactRoot();
+  const tmpRoot = opts.tmpRoot ?? "/tmp";
+  const keepPrior = opts.keepPrior ?? 1;
+  const dryRun = opts.dryRun ?? false;
+
+  // Determine which install-dir versions we plan to retain BEFORE
+  // pruning, so we can mirror the retention policy on artifact tarballs.
+  const installDirVersions = listInstalledVersions(installRoot, workloadId);
+  const retainedVersions = computeRetainedVersions(
+    installDirVersions,
+    currentVersion,
+    keepPrior
+  );
+
+  // --- 1. install dirs ---
+  let installDirsRemoved: string[] = [];
+  let installDirsBytes = 0;
+  for (const version of installDirVersions) {
+    if (retainedVersions.has(version)) continue;
+    const name = `${workloadId}-${version}`;
+    const full = join(installRoot, name);
+    installDirsBytes += pathSize(full);
+    if (!dryRun) rmSync(full, { recursive: true, force: true });
+    installDirsRemoved.push(name);
+  }
+
+  // --- 2. artifact tarballs ---
+  const artifacts = pruneArtifactTarballs(
+    artifactRoot,
+    workloadId,
+    retainedVersions,
+    dryRun
+  );
+
+  // --- 3. /tmp orphans (opt-in) ---
+  const tmpOrphans = opts.includeTmp
+    ? sweepTmpOrphans(tmpRoot, workloadId, dryRun)
+    : { removed: [], bytesFreed: 0 };
+
+  return {
+    workloadId,
+    currentVersion,
+    installDirs: { removed: installDirsRemoved, bytesFreed: installDirsBytes },
+    artifacts,
+    tmpOrphans,
+    bytesFreed:
+      installDirsBytes + artifacts.bytesFreed + tmpOrphans.bytesFreed,
+  };
+}
+
+/**
+ * List all installed versions of a workload under `installRoot`, by
+ * enumerating directory names matching `${workloadId}-*`. Returns
+ * bare version strings (no workloadId prefix), unsorted.
+ */
+function listInstalledVersions(
+  installRoot: string,
+  workloadId: string
+): string[] {
+  if (!existsSync(installRoot)) return [];
+  const prefix = `${workloadId}-`;
+  const versions: string[] = [];
+  for (const entry of readdirSync(installRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    if (!entry.name.startsWith(prefix)) continue;
+    versions.push(entry.name.slice(prefix.length));
+  }
+  return versions;
+}
+
+/**
+ * Determine which install-dir versions to retain: the current version
+ * (if it is present on disk) plus the `keepPrior` most-recent non-current
+ * versions by semver. When currentVersion is null, retain only the
+ * `keepPrior` most-recent versions on disk.
+ */
+function computeRetainedVersions(
+  available: string[],
+  currentVersion: string | null,
+  keepPrior: number
+): Set<string> {
+  const retain = new Set<string>();
+  if (keepPrior < 0) {
+    // Disabling retention means: retain everything (nothing gets pruned).
+    for (const v of available) retain.add(v);
+    if (currentVersion) retain.add(currentVersion);
+    return retain;
+  }
+  if (currentVersion && available.includes(currentVersion)) {
+    retain.add(currentVersion);
+  }
+  const priors = available
+    .filter((v) => v !== currentVersion)
+    .sort((a, b) => compareSemver(b, a));
+  for (const v of priors.slice(0, keepPrior)) retain.add(v);
+  return retain;
+}
+
 function homeDir(): string {
   const h = process.env.HOME;
   if (!h) throw new Error("HOME not set");
@@ -188,6 +453,10 @@ function homeDir(): string {
 
 function defaultInstallRoot(): string {
   return join(homeDir(), ".local/share/seed/workloads");
+}
+
+function defaultArtifactRoot(): string {
+  return join(homeDir(), ".local/share/seed/workload-artifacts");
 }
 
 function defaultPlistDir(): string {


### PR DESCRIPTION
## Summary
- Closes GAPS §1.4 (a), (b), and (c) — the three on-disk cleanup gaps that PR #22's install-time GC does not reach retroactively
- New `workload.gc` action + `seed fleet workload gc` subcommand
- Retro-cleans install-dirs, stale pre-staged artifact tarballs, and (opt-in) pre-v0.4 `/tmp` bootstrap orphans
- Scoped to reclaim the ~750MB of dead state currently on ren1

## Usage
```
seed fleet workload gc --machine <id> [--workload <id>]
                       [--keep-prior N] [--include-tmp] [--dry-run]
```

Per workload known to the target agent:
1. **Install-dirs** (§1.4a) — prune `~/.local/share/seed/workloads/${id}-*` not matching `current + keepPrior`
2. **Artifact tarballs** (§1.4b) — prune `~/.local/share/seed/workload-artifacts/${id}-*.tar.gz` not matching a retained install-dir version
3. **`/tmp` orphans** (§1.4c, opt-in via `--include-tmp`) — sweep `${id}-${semver}-*.tar.gz` and `seed-${id}-*.db` from `/tmp`, conservatively pattern-matched

`--dry-run` returns the full report (paths that would be removed, bytes that would be freed) without touching disk.

## Design notes
- Retention policy mirrors PR #22: `keepPrior=1` default, `=0` removes all non-current, `=-1` retains everything
- Artifact tarballs follow install-dir retention 1:1 — if we keep an install-dir, we keep its tarball
- When `currentVersion` is null (workload removed but install-dirs linger), the N most-recent versions are retained for rollback
- Agent returns structured JSON; CLI pretty-prints per-workload breakdown with human-readable byte counts
- `/tmp` sweep requires semver prefix in the filename, to avoid catching unrelated user files

## Test plan
- [x] 23 new unit tests for `pathSize`, `parseArtifactVersion`, `pruneArtifactTarballs`, `sweepTmpOrphans`, `gcWorkload`
- [x] Full fleet/control suite: 269 pass (+23 from baseline)
- [x] Typecheck clean (`tsc --noEmit` exit 0)
- [x] CLI arg parsing exercised locally: `seed fleet workload` prints usage; missing `--machine` errors; unknown flags rejected; main `seed fleet` help lists the new command
- [ ] End-to-end test against ren1 requires: build + release v0.4.6, roll out via `seed fleet release`, then `seed fleet workload gc --machine ren1 --dry-run` → review report → run without `--dry-run`