### PR TITLE
feat(fleet): fleet-topology workload — decouple seed.config.json from router releases

### DIFF
--- a/packages/fleet/control/src/agent.ts
+++ b/packages/fleet/control/src/agent.ts
@@ -896,6 +896,12 @@ async function runAgent() {
       }
       const r = workloadDb.get(workloadId);
       if (!r) return { success: false, output: `not installed: ${workloadId}` };
+      if (r.supervisor_label === "") {
+        return {
+          success: false,
+          output: `${workloadId} is a static workload (no supervisor to reload)`,
+        };
+      }
       const plistPath = `${process.env.HOME}/Library/LaunchAgents/${r.supervisor_label}.plist`;
       try {
         await supervisorDriver.unload(r.supervisor_label);
@@ -964,7 +970,12 @@ async function runAgent() {
       const r = workloadDb.get(workloadId);
       if (!r) return { success: true, output: `not installed: ${workloadId}` };
       try {
-        await supervisorDriver.unload(r.supervisor_label);
+        // Static workloads have no supervisor to unload — just drop
+        // the record. (The install-dir and symlink remain until
+        // workload.gc removes them.)
+        if (r.supervisor_label !== "") {
+          await supervisorDriver.unload(r.supervisor_label);
+        }
         workloadDb.delete(workloadId);
         return { success: true, output: `removed ${workloadId}` };
       } catch (err: any) {

--- a/packages/fleet/control/src/reconcile.test.ts
+++ b/packages/fleet/control/src/reconcile.test.ts
@@ -122,4 +122,29 @@ describe("planReconcile", () => {
       expect(routerAction.reason).toBe("version_mismatch");
     }
   });
+
+  test("static workload (empty supervisor_label) never emits drift/reload", () => {
+    // A static (file-drop) workload has no supervisor, so an empty
+    // loadedLabels set is the correct steady state — it must not be
+    // flagged as drift.
+    const actions = planReconcile({
+      declared: [decl("fleet-topology", "0.1.0")],
+      installed: [installed("fleet-topology", "0.1.0", "")],
+      loadedLabels: new Set(),
+    });
+    expect(actions).toEqual([]);
+  });
+
+  test("static workload at mismatched version still re-installs", () => {
+    const actions = planReconcile({
+      declared: [decl("fleet-topology", "0.2.0")],
+      installed: [installed("fleet-topology", "0.1.0", "")],
+      loadedLabels: new Set(),
+    });
+    expect(actions).toHaveLength(1);
+    expect(actions[0]?.kind).toBe("install");
+    if (actions[0]?.kind === "install") {
+      expect(actions[0].reason).toBe("version_mismatch");
+    }
+  });
 });

--- a/packages/fleet/control/src/reconcile.ts
+++ b/packages/fleet/control/src/reconcile.ts
@@ -70,6 +70,9 @@ export function planReconcile(inputs: ReconcileInputs): ReconcileAction[] {
     }
 
     // Version matches. Is the supervisor actually running it?
+    // Static workloads have no supervisor (empty supervisor_label),
+    // so there is nothing to drift — skip the check.
+    if (existing.supervisor_label === "") continue;
     if (!inputs.loadedLabels.has(existing.supervisor_label)) {
       actions.push({
         kind: "reload",

--- a/packages/fleet/control/src/types.ts
+++ b/packages/fleet/control/src/types.ts
@@ -433,8 +433,14 @@ export interface WorkloadManifest {
   description?: string;
   platform: "darwin" | "linux";
   arch: "arm64" | "x64";
-  /** Relative path inside the tarball to the main executable. */
-  binary: string;
+  /** Workload kind. "service" (default) = an installed long-running
+   *  process with a supervisor. "static" = files deposited on disk,
+   *  no supervisor, no binary — the install phase is the whole
+   *  lifecycle. Omit for "service" (back-compat). */
+  kind?: "service" | "static";
+  /** Relative path inside the tarball to the main executable. Required
+   *  for "service" workloads, ignored for "static". */
+  binary?: string;
   /** Non-executable files that must land alongside the binary. */
   sidecars?: Array<{ src: string; dest_rel: string }>;
   /** Env vars rendered into the supervisor spec. Values may reference
@@ -445,7 +451,9 @@ export interface WorkloadManifest {
   /** Port the workload listens on (used for discovery + health probes). */
   port?: number;
   probe?: { type: "http" | "tcp"; path?: string };
-  supervisor: {
+  /** Supervisor spec — required for "service" workloads, omitted for
+   *  "static" workloads (no process to supervise). */
+  supervisor?: {
     launchd?: {
       label: string;
       template: string;
@@ -458,6 +466,16 @@ export interface WorkloadManifest {
   };
   /** sha256 hex digests, keyed by tarball-relative path. */
   checksums?: Record<string, string>;
+}
+
+/**
+ * True if the manifest describes a "static" (file-drop) workload —
+ * one that deposits files on disk and has no long-running process.
+ * Static workloads update the `${workloadId}-current` symlink to
+ * their install dir so consumers can read from a stable path.
+ */
+export function isStaticWorkload(m: WorkloadManifest): boolean {
+  return m.kind === "static";
 }
 
 /**

--- a/packages/fleet/control/src/workload-installer.test.ts
+++ b/packages/fleet/control/src/workload-installer.test.ts
@@ -14,6 +14,7 @@ import {
   pruneArtifactTarballs,
   sweepTmpOrphans,
   gcWorkload,
+  updateCurrentSymlink,
 } from "./workload-installer";
 import type { WorkloadManifest, WorkloadDeclaration } from "./types";
 import type { SupervisorDriver } from "./supervisors/launchd";
@@ -29,11 +30,11 @@ function buildFakeArtifact(stageDir: string, manifest: WorkloadManifest): string
 
   // Fake binary — just an exec-able script that echoes.
   const binaryContent = "#!/bin/sh\necho fake workload\n";
-  writeFileSync(join(stageDir, manifest.binary), binaryContent, { mode: 0o755 });
+  writeFileSync(join(stageDir, manifest.binary!), binaryContent, { mode: 0o755 });
 
   // Fake launchd template with every token the installer renders.
   writeFileSync(
-    join(stageDir, manifest.supervisor.launchd!.template),
+    join(stageDir, manifest.supervisor!.launchd!.template),
     `<?xml version="1.0" encoding="UTF-8"?>
 <plist><dict>
 <key>Label</key><string>@@LABEL@@</string>
@@ -760,5 +761,234 @@ describe("gcWorkload", () => {
     expect(report.artifacts.removed).toEqual([]);
     expect(report.tmpOrphans.removed).toEqual([]);
     expect(report.bytesFreed).toBe(0);
+  });
+});
+
+describe("updateCurrentSymlink", () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "seed-symlink-"));
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("creates symlink when absent, pointing at ${id}-${version}", () => {
+    const { lstatSync, readlinkSync } = require("node:fs");
+    mkdirSync(join(root, "memory-0.4.9"), { recursive: true });
+    updateCurrentSymlink(root, "memory", "0.4.9");
+    const linkPath = join(root, "memory-current");
+    const st = lstatSync(linkPath);
+    expect(st.isSymbolicLink()).toBe(true);
+    expect(readlinkSync(linkPath)).toBe("memory-0.4.9");
+  });
+
+  test("atomically updates an existing symlink to a new version", () => {
+    const { readlinkSync } = require("node:fs");
+    mkdirSync(join(root, "memory-0.4.8"), { recursive: true });
+    mkdirSync(join(root, "memory-0.4.9"), { recursive: true });
+    updateCurrentSymlink(root, "memory", "0.4.8");
+    expect(readlinkSync(join(root, "memory-current"))).toBe("memory-0.4.8");
+    updateCurrentSymlink(root, "memory", "0.4.9");
+    expect(readlinkSync(join(root, "memory-current"))).toBe("memory-0.4.9");
+  });
+
+  test("different workloads get different symlinks", () => {
+    const { readlinkSync } = require("node:fs");
+    mkdirSync(join(root, "memory-0.4.9"), { recursive: true });
+    mkdirSync(join(root, "fleet-router-1.0.0"), { recursive: true });
+    updateCurrentSymlink(root, "memory", "0.4.9");
+    updateCurrentSymlink(root, "fleet-router", "1.0.0");
+    expect(readlinkSync(join(root, "memory-current"))).toBe("memory-0.4.9");
+    expect(readlinkSync(join(root, "fleet-router-current"))).toBe("fleet-router-1.0.0");
+  });
+
+  test("no-op on non-existent installRoot", () => {
+    rmSync(root, { recursive: true, force: true });
+    expect(() =>
+      updateCurrentSymlink(root, "memory", "0.4.9")
+    ).not.toThrow();
+  });
+
+  test("resolves to version dir content through the symlink", () => {
+    mkdirSync(join(root, "config-0.1.0"), { recursive: true });
+    writeFileSync(join(root, "config-0.1.0", "data.json"), '{"v":1}');
+    updateCurrentSymlink(root, "config", "0.1.0");
+    const body = readFileSync(join(root, "config-current", "data.json"), "utf-8");
+    expect(body).toBe('{"v":1}');
+  });
+
+  test("cleans up a stale .tmp link from a prior crash", () => {
+    const { symlinkSync, lstatSync } = require("node:fs");
+    mkdirSync(join(root, "memory-0.4.9"), { recursive: true });
+    // simulate a crashed prior update
+    symlinkSync("memory-0.4.7", join(root, "memory-current.tmp"));
+    updateCurrentSymlink(root, "memory", "0.4.9");
+    // .tmp must be gone, real link points at the new version
+    expect(() => lstatSync(join(root, "memory-current.tmp"))).toThrow();
+    expect(lstatSync(join(root, "memory-current")).isSymbolicLink()).toBe(true);
+  });
+});
+
+describe("installWorkload static (file-drop) workloads", () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "seed-static-install-"));
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  const buildStaticArtifact = (stageDir: string, manifest: WorkloadManifest): string => {
+    mkdirSync(stageDir, { recursive: true });
+    writeFileSync(join(stageDir, "config.json"), '{"providers":[]}');
+    writeFileSync(join(stageDir, "manifest.json"), JSON.stringify(manifest, null, 2));
+    const tarball = join(stageDir, "..", "static.tar.gz");
+    const proc = Bun.spawnSync(["tar", "-czf", tarball, "-C", stageDir, "."]);
+    if (proc.exitCode !== 0) throw new Error("tar failed");
+    return tarball;
+  };
+
+  test("extracts files, skips supervisor, records state=installed", async () => {
+    const stageDir = join(tmp, "stage");
+    const manifest: WorkloadManifest = {
+      id: "fleet-topology",
+      version: "0.1.0",
+      kind: "static",
+      platform: "darwin",
+      arch: "arm64",
+    };
+    const tarball = buildStaticArtifact(stageDir, manifest);
+    const decl: WorkloadDeclaration = {
+      id: "fleet-topology",
+      version: "0.1.0",
+      artifact_url: `file://${tarball}`,
+    };
+
+    const driver = mockDriver();
+    const installRoot = join(tmp, "installs");
+    const result = await installWorkload(decl, {
+      driver,
+      installRoot,
+      plistDir: join(tmp, "plists"),
+      logDir: join(tmp, "logs"),
+    });
+
+    expect(result.record.state).toBe("installed");
+    expect(result.record.supervisor_label).toBe("");
+    expect(result.plistPath).toBe("");
+    // File is on disk
+    expect(existsSync(join(result.record.install_dir, "config.json"))).toBe(true);
+    // Driver was NOT asked to load/unload anything
+    expect(driver.calls).toEqual([]);
+  });
+
+  test("maintains ${id}-current symlink after install", async () => {
+    const { readlinkSync } = require("node:fs");
+    const stageDir = join(tmp, "stage");
+    const manifest: WorkloadManifest = {
+      id: "fleet-topology",
+      version: "0.1.0",
+      kind: "static",
+      platform: "darwin",
+      arch: "arm64",
+    };
+    const tarball = buildStaticArtifact(stageDir, manifest);
+    const decl: WorkloadDeclaration = {
+      id: "fleet-topology",
+      version: "0.1.0",
+      artifact_url: `file://${tarball}`,
+    };
+
+    const installRoot = join(tmp, "installs");
+    await installWorkload(decl, {
+      driver: mockDriver(),
+      installRoot,
+      plistDir: join(tmp, "plists"),
+      logDir: join(tmp, "logs"),
+    });
+
+    const linkPath = join(installRoot, "fleet-topology-current");
+    expect(readlinkSync(linkPath)).toBe("fleet-topology-0.1.0");
+    // Read through the symlink
+    const body = readFileSync(join(linkPath, "config.json"), "utf-8");
+    expect(body).toBe('{"providers":[]}');
+  });
+
+  test("second static install updates the symlink to the new version", async () => {
+    const { readlinkSync } = require("node:fs");
+    const installRoot = join(tmp, "installs");
+
+    for (const version of ["0.1.0", "0.2.0"]) {
+      const stageDir = join(tmp, `stage-${version}`);
+      const manifest: WorkloadManifest = {
+        id: "fleet-topology",
+        version,
+        kind: "static",
+        platform: "darwin",
+        arch: "arm64",
+      };
+      const tarball = buildStaticArtifact(stageDir, manifest);
+      await installWorkload(
+        {
+          id: "fleet-topology",
+          version,
+          artifact_url: `file://${tarball}`,
+        },
+        {
+          driver: mockDriver(),
+          installRoot,
+          plistDir: join(tmp, "plists"),
+          logDir: join(tmp, "logs"),
+          keepPrior: 1,
+        }
+      );
+    }
+
+    expect(readlinkSync(join(installRoot, "fleet-topology-current"))).toBe(
+      "fleet-topology-0.2.0"
+    );
+  });
+});
+
+describe("installWorkload service workloads maintain current symlink", () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "seed-svc-symlink-"));
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("symlink points at version dir after successful service install", async () => {
+    const { readlinkSync } = require("node:fs");
+    const stageDir = join(tmp, "stage");
+    const manifest: WorkloadManifest = {
+      id: "test-workload",
+      version: "0.1.0",
+      platform: "darwin",
+      arch: "arm64",
+      binary: "bin/worker",
+      supervisor: {
+        launchd: { label: "com.test.worker", template: "templates/launchd.plist.template" },
+      },
+    };
+    const tarball = buildFakeArtifact(stageDir, manifest);
+    const driver = mockDriver();
+    const installRoot = join(tmp, "installs");
+
+    await installWorkload(
+      { id: "test-workload", version: "0.1.0", artifact_url: `file://${tarball}` },
+      {
+        driver,
+        installRoot,
+        plistDir: join(tmp, "plists"),
+        logDir: join(tmp, "logs"),
+      }
+    );
+
+    expect(readlinkSync(join(installRoot, "test-workload-current"))).toBe(
+      "test-workload-0.1.0"
+    );
   });
 });

--- a/packages/fleet/control/src/workload-installer.ts
+++ b/packages/fleet/control/src/workload-installer.ts
@@ -23,6 +23,7 @@ import type {
   WorkloadDeclaration,
   WorkloadInstallRecord,
 } from "./types";
+import { isStaticWorkload } from "./types";
 import type { SupervisorDriver } from "./supervisors/launchd";
 import { renderTemplate, resolveEnv, renderPlistEnvDict } from "./templates";
 
@@ -445,6 +446,37 @@ function computeRetainedVersions(
   return retain;
 }
 
+/**
+ * Maintain the `${workloadId}-current` symlink pointing at the
+ * install dir for `currentVersion`. Atomic: writes to `.tmp` and
+ * renames over any existing symlink. A non-existent installRoot is
+ * a no-op. Safe to call repeatedly.
+ *
+ * Consumers (routers, other workloads, operators) can read through
+ * `${installRoot}/${workloadId}-current/...` for a path that follows
+ * the latest install without encoding the version.
+ */
+export function updateCurrentSymlink(
+  installRoot: string,
+  workloadId: string,
+  currentVersion: string
+): void {
+  if (!existsSync(installRoot)) return;
+  const linkPath = join(installRoot, `${workloadId}-current`);
+  const target = `${workloadId}-${currentVersion}`; // relative target
+  const { symlinkSync, renameSync, lstatSync } = require("node:fs") as typeof import("node:fs");
+  const tmpLink = `${linkPath}.tmp`;
+  // Clean up any stale tmp link.
+  try {
+    lstatSync(tmpLink);
+    rmSync(tmpLink, { force: true });
+  } catch {
+    // not present, continue
+  }
+  symlinkSync(target, tmpLink);
+  renameSync(tmpLink, linkPath);
+}
+
 function homeDir(): string {
   const h = process.env.HOME;
   if (!h) throw new Error("HOME not set");
@@ -524,68 +556,107 @@ export async function installWorkload(
   // 5. Verify checksums of extracted files.
   verifyInstalledChecksums(manifest, installDir);
 
-  // 6. Ensure binary is executable.
-  const binaryPath = join(installDir, manifest.binary);
-  if (!existsSync(binaryPath)) {
-    throw new Error(`binary ${manifest.binary} not found in install dir`);
-  }
-  const { chmodSync } = await import("node:fs");
-  chmodSync(binaryPath, 0o755);
-  if (manifest.sidecars) {
-    for (const s of manifest.sidecars) {
-      const sp = join(installDir, s.dest_rel);
-      if (existsSync(sp)) chmodSync(sp, 0o755);
+  // Static workloads branch here: no binary, no supervisor, no plist.
+  // The install phase itself IS the workload — files are extracted to
+  // installDir and the `${id}-current` symlink is moved to point at
+  // it, and that's the whole lifecycle. Consumers read through the
+  // stable symlink path.
+  let plistPath = "";
+  let supervisorLabel = "";
+  let state: WorkloadInstallRecord["state"] = "loaded";
+
+  if (isStaticWorkload(manifest)) {
+    state = "installed";
+    // Static workloads may still include sidecar chmod hints (e.g. for
+    // scripts), but there is no main binary to chmod.
+    if (manifest.sidecars) {
+      const { chmodSync } = await import("node:fs");
+      for (const s of manifest.sidecars) {
+        const sp = join(installDir, s.dest_rel);
+        if (existsSync(sp)) chmodSync(sp, 0o755);
+      }
     }
+  } else {
+    // 6. Ensure binary is executable.
+    if (!manifest.binary) {
+      throw new Error(
+        `manifest missing binary (required for kind="service")`
+      );
+    }
+    const binaryPath = join(installDir, manifest.binary);
+    if (!existsSync(binaryPath)) {
+      throw new Error(`binary ${manifest.binary} not found in install dir`);
+    }
+    const { chmodSync } = await import("node:fs");
+    chmodSync(binaryPath, 0o755);
+    if (manifest.sidecars) {
+      for (const s of manifest.sidecars) {
+        const sp = join(installDir, s.dest_rel);
+        if (existsSync(sp)) chmodSync(sp, 0o755);
+      }
+    }
+
+    // 7. Render the launchd template.
+    const supervisor = manifest.supervisor?.launchd;
+    if (!supervisor) {
+      throw new Error(
+        "manifest missing supervisor.launchd — Phase 1 is macOS-only"
+      );
+    }
+    const templatePath = join(installDir, supervisor.template);
+    if (!existsSync(templatePath)) {
+      throw new Error(`supervisor template not found: ${supervisor.template}`);
+    }
+    const template = readFileSync(templatePath, "utf-8");
+
+    const logPath = join(logDir, `${supervisor.label}.log`);
+    const tokens: Record<string, string> = {
+      BINARY: binaryPath,
+      INSTALL_DIR: installDir,
+      INSTALL_ROOT: installRoot,
+      HOME: homeDir(),
+      LABEL: supervisor.label,
+      LOG_PATH: logPath,
+    };
+
+    // Resolve env (manifest defaults ← declaration overrides, then expand
+    // {{install_dir}}-style placeholders against our token map).
+    const env = resolveEnv(manifest.env, declaration.env, tokens);
+    tokens.ENV = renderPlistEnvDict(env);
+
+    const renderedPlist = renderTemplate(template, tokens);
+
+    // 8. Write the plist atomically.
+    mkdirSync(plistDir, { recursive: true });
+    mkdirSync(dirname(logPath), { recursive: true });
+    plistPath = join(plistDir, `${supervisor.label}.plist`);
+    const tmpPlist = `${plistPath}.tmp`;
+    writeFileSync(tmpPlist, renderedPlist, { mode: 0o644 });
+    const { renameSync } = await import("node:fs");
+    renameSync(tmpPlist, plistPath);
+
+    // 9. Unload first to make this idempotent for same-version reloads,
+    //    then bootstrap.
+    await opts.driver.unload(supervisor.label);
+    await opts.driver.load(supervisor.label, plistPath);
+
+    supervisorLabel = supervisor.label;
   }
 
-  // 7. Render the launchd template.
-  const supervisor = manifest.supervisor.launchd;
-  if (!supervisor) {
-    throw new Error("manifest missing supervisor.launchd — Phase 1 is macOS-only");
-  }
-  const templatePath = join(installDir, supervisor.template);
-  if (!existsSync(templatePath)) {
-    throw new Error(`supervisor template not found: ${supervisor.template}`);
-  }
-  const template = readFileSync(templatePath, "utf-8");
-
-  const logPath = join(logDir, `${supervisor.label}.log`);
-  const tokens: Record<string, string> = {
-    BINARY: binaryPath,
-    INSTALL_DIR: installDir,
-    HOME: homeDir(),
-    LABEL: supervisor.label,
-    LOG_PATH: logPath,
-  };
-
-  // Resolve env (manifest defaults ← declaration overrides, then expand
-  // {{install_dir}}-style placeholders against our token map).
-  const env = resolveEnv(manifest.env, declaration.env, tokens);
-  tokens.ENV = renderPlistEnvDict(env);
-
-  const renderedPlist = renderTemplate(template, tokens);
-
-  // 8. Write the plist atomically.
-  mkdirSync(plistDir, { recursive: true });
-  mkdirSync(dirname(logPath), { recursive: true });
-  const plistPath = join(plistDir, `${supervisor.label}.plist`);
-  const tmpPlist = `${plistPath}.tmp`;
-  writeFileSync(tmpPlist, renderedPlist, { mode: 0o644 });
-  const { renameSync } = await import("node:fs");
-  renameSync(tmpPlist, plistPath);
-
-  // 9. Unload first to make this idempotent for same-version reloads,
-  //    then bootstrap.
-  await opts.driver.unload(supervisor.label);
-  await opts.driver.load(supervisor.label, plistPath);
+  // Move the `${id}-current` symlink to point at this install. Both
+  // static and service workloads maintain this so consumers on the
+  // same machine can read through a stable path that does not encode
+  // the version (routers referring to a shared config, operators
+  // inspecting latest install, etc.).
+  updateCurrentSymlink(installRoot, manifest.id, manifest.version);
 
   const record: WorkloadInstallRecord = {
     workload_id: manifest.id,
     version: manifest.version,
     install_dir: installDir,
-    supervisor_label: supervisor.label,
+    supervisor_label: supervisorLabel,
     installed_at: new Date().toISOString(),
-    state: "loaded",
+    state,
     failure_reason: null,
     last_probe_at: null,
     last_probe_tier: null,

--- a/packages/fleet/control/src/workload-runner.ts
+++ b/packages/fleet/control/src/workload-runner.ts
@@ -36,8 +36,10 @@ export interface ReconcileSummary {
 async function listLoadedLabels(driver: SupervisorDriver, records: WorkloadInstallRecord[]): Promise<Set<string>> {
   // We only need to know about labels we care about. Query status
   // per-record to avoid parsing `launchctl list` (no label filter).
+  // Static workloads have no label — skip them.
   const loaded = new Set<string>();
   for (const r of records) {
+    if (r.supervisor_label === "") continue;
     if (await driver.isLoaded(r.supervisor_label)) {
       loaded.add(r.supervisor_label);
     }

--- a/packages/fleet/topology/package.json
+++ b/packages/fleet/topology/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@seed/fleet-topology",
+  "version": "0.1.0",
+  "description": "Static (file-drop) workload that deposits seed.config.json on a fleet machine. Decouples fleet topology from router release cadence.",
+  "type": "module",
+  "scripts": {
+    "build:artifact": "bash scripts/build-artifact.sh"
+  }
+}

--- a/packages/fleet/topology/scripts/build-artifact.sh
+++ b/packages/fleet/topology/scripts/build-artifact.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Build a static workload artifact bundle for @seed/fleet-topology.
+#
+# Produces: dist/artifacts/fleet-topology-<version>-<platform>-<arch>.tar.gz
+#
+# Each tarball contains:
+#   manifest.json (kind: "static")
+#   seed.config.json
+#
+# The installer extracts this bundle to
+# ~/.local/share/seed/workloads/fleet-topology-<version>/ and updates
+# the fleet-topology-current symlink. Consumers (fleet-router, etc.)
+# read through the symlink for a stable path that follows the latest
+# installed version.
+#
+# Platform/arch are recorded in the manifest but have no effect — the
+# payload is a JSON file. Tarballs are built per-platform to match
+# the WorkloadDeclaration resolution convention used by the control
+# plane's artifact server, not because the content differs.
+#
+# Usage:
+#   bash scripts/build-artifact.sh [--version <ver>]
+#   bash scripts/build-artifact.sh --targets "darwin-arm64 linux-x64"
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PKG_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$PKG_DIR/../../.." && pwd)"
+DIST_DIR="$PKG_DIR/dist"
+ARTIFACTS_DIR="$DIST_DIR/artifacts"
+
+VERSION=""
+TARGETS="darwin-arm64 darwin-x64 linux-x64"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --version) VERSION="$2"; shift 2 ;;
+    --targets) TARGETS="$2"; shift 2 ;;
+    -h|--help) grep '^#' "$0" | head -25; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [ -z "$VERSION" ]; then
+  VERSION=$(node -p "require('$PKG_DIR/package.json').version")
+fi
+
+SEED_CONFIG_SRC="${SEED_CONFIG_SRC:-$REPO_ROOT/seed.config.json}"
+if [ ! -f "$SEED_CONFIG_SRC" ]; then
+  echo "error: seed.config.json not found at $SEED_CONFIG_SRC" >&2
+  echo "  (it is gitignored — copy it from the primary worktree, or set SEED_CONFIG_SRC)" >&2
+  exit 1
+fi
+
+mkdir -p "$ARTIFACTS_DIR"
+
+for target in $TARGETS; do
+  platform="${target%-*}"
+  arch="${target##*-}"
+
+  stage="$ARTIFACTS_DIR/stage-$target"
+  rm -rf "$stage"
+  mkdir -p "$stage"
+
+  cp "$SEED_CONFIG_SRC" "$stage/seed.config.json"
+
+  config_sha=$(shasum -a 256 "$stage/seed.config.json" | awk '{print $1}')
+
+  cat > "$stage/manifest.json" <<EOF
+{
+  "id": "fleet-topology",
+  "version": "$VERSION",
+  "kind": "static",
+  "description": "Fleet topology (machines, providers, models) — seed.config.json as a standalone workload",
+  "platform": "$platform",
+  "arch": "$arch",
+  "checksums": {
+    "seed.config.json": "sha256:$config_sha"
+  }
+}
+EOF
+
+  tarball="$ARTIFACTS_DIR/fleet-topology-$VERSION-$target.tar.gz"
+  ( cd "$stage" && tar -czf "$tarball" . )
+  rm -rf "$stage"
+  echo "  + $tarball"
+done
+
+echo ""
+echo "==> Artifact checksums"
+( cd "$ARTIFACTS_DIR" && shasum -a 256 fleet-topology-*.tar.gz )
+
+echo ""
+echo "==> Done."

--- a/packages/inference/router/scripts/build-artifact.sh
+++ b/packages/inference/router/scripts/build-artifact.sh
@@ -75,6 +75,11 @@ for target in $TARGETS; do
   chmod +x "$stage/bin/fleet-router"
   cp "$PKG_DIR/src/start-mlx-server.py" "$stage/bin/start-mlx-server.py"
   cp "$PKG_DIR/workload/launchd.plist.template" "$stage/templates/launchd.plist.template"
+  # Fallback copy of seed.config.json so a router install can still boot
+  # before fleet-topology is installed on a given machine. The manifest
+  # env points SEED_CONFIG at the fleet-topology-current symlink; when
+  # that path doesn't exist yet, the router's loadRouterConfig() falls
+  # through to the legacy in-install-dir path (see router/src/config.ts).
   cp "$SEED_CONFIG_SRC" "$stage/seed.config.json"
 
   bin_sha=$(shasum -a 256 "$stage/bin/fleet-router" | awk '{print $1}')
@@ -99,7 +104,8 @@ for target in $TARGETS; do
     "MLX_MODEL": "mlx-community/Qwen3.5-9B-MLX-4bit",
     "MLX_PYTHON_PATH": "/opt/homebrew/bin/python3.11",
     "MLX_STARTER_PATH": "{{install_dir}}/bin/start-mlx-server.py",
-    "SEED_CONFIG": "{{install_dir}}/seed.config.json",
+    "SEED_CONFIG": "{{install_root}}/fleet-topology-current/seed.config.json",
+    "SEED_CONFIG_FALLBACK": "{{install_dir}}/seed.config.json",
     "PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
   },
   "required_env": [],

--- a/packages/inference/router/src/config.ts
+++ b/packages/inference/router/src/config.ts
@@ -293,10 +293,22 @@ function loadFromEnvOnly(): LoadedRouterConfig {
 
 export function loadRouterConfig(): LoadedRouterConfig {
   const seedConfigPath = process.env.SEED_CONFIG ?? resolve(import.meta.dir, "..", "..", "..", "..", "seed.config.json");
+  // Set by the router workload manifest to the in-install-dir copy
+  // that ships with the router tarball. Used when SEED_CONFIG points
+  // at the fleet-topology-current symlink but fleet-topology has not
+  // been installed on this machine yet.
+  const fallbackConfigPath = process.env.SEED_CONFIG_FALLBACK;
   const legacyConfigPath = process.env.FLEET_CONFIG ?? resolve(import.meta.dir, "..", "fleet.config.json");
 
   if (existsSync(seedConfigPath)) {
     return loadFromSeedConfig(seedConfigPath);
+  }
+
+  if (fallbackConfigPath && existsSync(fallbackConfigPath)) {
+    console.warn(
+      `[router] SEED_CONFIG ${seedConfigPath} not found; falling back to ${fallbackConfigPath}`
+    );
+    return loadFromSeedConfig(fallbackConfigPath);
   }
 
   if (existsSync(legacyConfigPath)) {


### PR DESCRIPTION
## Summary
Closes GAPS §1.2 by turning fleet topology into its own workload with its own lifecycle. Topology changes no longer require a router rebuild.

## What landed
1. **New \"static\" workload kind** — manifest `kind: \"static\"` means file-drop only: extract, verify checksums, done. No binary, no supervisor, no plist. Installer branches on kind; reconcile + runner handle the empty supervisor_label correctly.
2. **`${workloadId}-current` stable symlink** — every successful install (static or service) updates the symlink atomically. Gives cross-workload consumers a path that follows the latest install without encoding version.
3. **`@seed/fleet-topology` package** — static workload containing just seed.config.json + its manifest.
4. **Router manifest env update** — `SEED_CONFIG` now points at `{{install_root}}/fleet-topology-current/seed.config.json`. New `SEED_CONFIG_FALLBACK` points at the in-router-tarball copy (still bundled). Router's `loadRouterConfig()` falls back to the in-router copy if the shared symlink doesn't exist yet — so new router installs boot even before fleet-topology is installed.

## Deploy flow (post-merge)
1. Build the fleet-topology artifact
2. Publish + declare in the CP workload config for ren3
3. `workload.install fleet-topology` → symlink created, router picks it up on next restart
4. Future topology changes: bump fleet-topology version → rebuild tiny tarball → `workload.install` → restart router. No router rebuild needed.

## Test plan
- [x] 12 new tests (6 symlink, 3 static install, 1 service+symlink regression, 2 reconcile)
- [x] 281 tests pass in fleet/control (+12 from 269 baseline)
- [x] Router suite: 16 pass, unchanged
- [x] Typecheck clean
- [x] Local artifact build works (`bash packages/fleet/topology/scripts/build-artifact.sh --targets darwin-arm64` produces a well-formed tarball)
- [ ] Post-deploy on ren3: verify `~/.local/share/seed/workloads/fleet-topology-current/seed.config.json` readable + router picks up config via shared path