### PR TITLE
chore(memory): bump to 0.4.10 for safeInsertEmbedding telemetry

### DIFF
--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seed/memory",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "type": "module",
   "scripts": {
     "server": "bun run src/main.ts",


### PR DESCRIPTION
## Summary
- Bumps `@seed/memory` from 0.4.9 to 0.4.10
- Unblocks deploy of `safeInsertEmbedding` (PR #28) to ren1 — current ren1 install is 0.4.9 with pre-#28 code, so the version bump is required for the installer to treat it as a new install

## Why
Without this bump, v0.4.6's memory tarball ships as `memory-0.4.9-*.tar.gz` with the new observability code, but the workload installer skips it because ren1 already has `memory-0.4.9` installed. Bumping to 0.4.10 + cutting v0.4.7 will produce the `skipped: {reason→count}` telemetry needed for the vec0 PK root-cause (GAPS §1.1).