### PR TITLE
fix(release): stamp SEED_VERSION from tag name at build time

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,24 @@ jobs:
           echo "sqlite-vec native extensions ready:"
           ls node_modules/sqlite-vec-*/vec0.*
 
+      - name: Stamp version
+        # Overwrite SEED_VERSION in version.ts with the tag name (minus the
+        # leading `v`) so the compiled binaries report the release version
+        # they were built from. Without this step every published binary
+        # reports whatever literal is checked into main, which has proven
+        # easy to forget to bump (resulting in `seed fleet release` always
+        # timing out because its success predicate compares agent_version
+        # against the target tag).
+        shell: bash
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          FILE="packages/fleet/control/src/version.ts"
+          echo "stamping $FILE with version $VERSION"
+          # Portable in-place sed: write to tmp then move (works on macOS + Linux).
+          sed -E "s/export const SEED_VERSION = \"[^\"]+\";/export const SEED_VERSION = \"$VERSION\";/" "$FILE" > "$FILE.tmp"
+          mv "$FILE.tmp" "$FILE"
+          grep "SEED_VERSION" "$FILE"
+
       - name: Build fleet-control binaries
         working-directory: packages/fleet/control
         run: bash scripts/build-binaries.sh

--- a/packages/fleet/control/src/version.ts
+++ b/packages/fleet/control/src/version.ts
@@ -5,9 +5,13 @@
  * this constant. The version is compared against GitHub Releases tags
  * (prefixed with `v`) to decide whether a self-update is needed.
  *
- * Bump this in lockstep with the `v*.*.*` tag used to cut a release.
+ * The default "0.0.0-dev" value applies to local builds. The release
+ * workflow stamps this file with the actual tag version (stripped of
+ * the `v` prefix) before running `bun build --compile`, so published
+ * binaries always report the version of the tag that produced them.
+ * See `.github/workflows/release.yml` — the "Stamp version" step.
  */
-export const SEED_VERSION = "0.4.5";
+export const SEED_VERSION = "0.0.0-dev";
 
 /** GitHub repo that publishes releases (owner/name). */
 export const SEED_REPO = "phyter1/seed";


### PR DESCRIPTION
## Summary
Fixes a silent drift bug that broke `seed fleet release` for every rollout after v0.4.5.

## Root cause
`packages/fleet/control/src/version.ts` exports a hand-maintained `SEED_VERSION` string used by all three binaries (agent, CLI, control plane). It had to be bumped in lockstep with each release tag. After v0.4.5 it wasn't — so v0.4.6 and v0.4.7 binaries both ship reporting version `0.4.5`.

The self-update path works fine (binaries on disk do get replaced; the sha256 on each node matches the release checksum). The breakage is in the success predicate of `seed fleet release`, which waits for `agent_version === targetTag` after dispatch. Since agents keep reporting 0.4.5, the wait always times out — even when the rollout completed in <5s.

## Fix
- Default `SEED_VERSION` → `"0.0.0-dev"` (makes local builds clearly distinguishable)
- Add a "Stamp version" step to `.github/workflows/release.yml` that rewrites `version.ts` with the tag name (minus `v` prefix) immediately before `bun build --compile`

This removes the manual-sync requirement. The tag IS the version; the binary reports what it was built from.

## Verification
- Sed is portable (tmp-file + mv, no `-i` flag variance between macOS/Linux)
- 281 fleet-control tests still pass
- No tests reference `SEED_VERSION` directly, so the default change has no fallout