### PR TITLE
ci: add test workflow for PRs (EPIC-010)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,46 @@
+name: Test
+
+# PR gate: typecheck + test every package with a test suite.
+#
+# Runs on pull_request against main and on push to main. Each package
+# in the matrix installs its own deps, typechecks, then runs bun test.
+# Mirrors the dev loop documented in CLAUDE.md:
+#   bun install && bunx tsc --noEmit && bun test
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - packages/fleet/control
+          - packages/memory
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        working-directory: ${{ matrix.package }}
+        run: bun install
+
+      - name: Typecheck
+        working-directory: ${{ matrix.package }}
+        run: bunx tsc --noEmit
+
+      - name: Test
+        working-directory: ${{ matrix.package }}
+        run: bun test


### PR DESCRIPTION
## What

Adds `.github/workflows/test.yml`, a PR-gate workflow that runs on every `pull_request` targeting `main` and every `push` to `main`.

For each of the two test-bearing packages (`packages/fleet/control`, `packages/memory`) it runs:

1. `bun install`
2. `bunx tsc --noEmit`
3. `bun test`

Mirrors the dev loop from `CLAUDE.md`. Matrix over the two packages, `fail-fast: false` so one package's failure doesn't mask the other.

## Why

Today `release.yml` is the only workflow — PRs merge with zero automated verification. EPIC-010 in GAPS §6 called this out as the highest-leverage gap. This PR closes it.

The PR itself is the proof-of-life: the new workflow runs against this change.

Closes EPIC-010.