### PR TITLE
fix(router): wait for port release before MLX respawn (#38)

### DIFF
--- a/packages/inference/router/package.json
+++ b/packages/inference/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seed/router",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Rule-based fleet router with deterministic keyword routing, MLX thinking lifecycle, and jury mode",
   "type": "module",
   "scripts": {

--- a/packages/inference/router/src/mlx-supervisor.test.ts
+++ b/packages/inference/router/src/mlx-supervisor.test.ts
@@ -72,6 +72,7 @@ class FakeClock {
 function makeSupervisor(opts: {
   maxConsecutiveFailures?: number;
   backoffSchedule?: number[];
+  waitPortFree?: () => Promise<number>;
 } = {}) {
   const clock = new FakeClock();
   const procs: FakeProc[] = [];
@@ -92,9 +93,14 @@ function makeSupervisor(opts: {
     now: clock.now,
     backoffSchedule: opts.backoffSchedule,
     maxConsecutiveFailures: opts.maxConsecutiveFailures,
+    waitPortFree: opts.waitPortFree,
   });
 
   return { supervisor, clock, procs, spawnCalls, logs };
+}
+
+async function drainMicrotasks(n = 4): Promise<void> {
+  for (let i = 0; i < n; i++) await Promise.resolve();
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────────
@@ -283,6 +289,7 @@ describe("getState snapshot", () => {
       consecutiveFailures: 0,
       isHealthy: false,
       givenUp: false,
+      lastPortWaitMs: null,
     });
   });
 });
@@ -302,6 +309,63 @@ describe("intentional/respawn races", () => {
     procs[1].die(1);
     expect(clock.pendingCount()).toBe(1); // respawn scheduled
     expect(supervisor.getState().consecutiveFailures).toBe(1);
+  });
+});
+
+describe("waitPortFree (issue #38)", () => {
+  test("respawn waits for the port-free probe to resolve before spawning", async () => {
+    let resolvePort: ((ms: number) => void) | null = null;
+    const waitPortFree = () => new Promise<number>((r) => { resolvePort = r; });
+    const { supervisor, procs, clock } = makeSupervisor({ waitPortFree });
+
+    supervisor.start(false);
+    procs[0].die(1);
+    clock.fireNext(); // fire backoff timer
+
+    // Port probe is pending — no new child yet.
+    await drainMicrotasks();
+    expect(procs).toHaveLength(1);
+    expect(supervisor.getState().respawnCount).toBe(0);
+
+    // Port is free; probe resolves with 42ms wait.
+    resolvePort!(42);
+    await drainMicrotasks();
+
+    expect(procs).toHaveLength(2);
+    expect(supervisor.getState().respawnCount).toBe(1);
+    expect(supervisor.getState().lastPortWaitMs).toBe(42);
+  });
+
+  test("probe rejection does not block the respawn (degraded mode)", async () => {
+    let rejectPort: ((err: Error) => void) | null = null;
+    const waitPortFree = () => new Promise<number>((_, rej) => { rejectPort = rej; });
+    const { supervisor, procs, clock, logs } = makeSupervisor({ waitPortFree });
+
+    supervisor.start(false);
+    procs[0].die(1);
+    clock.fireNext();
+
+    await drainMicrotasks();
+    expect(procs).toHaveLength(1);
+
+    rejectPort!(new Error("timeout"));
+    await drainMicrotasks();
+
+    expect(procs).toHaveLength(2);
+    expect(supervisor.getState().respawnCount).toBe(1);
+    expect(logs.some((m) => /port wait failed/i.test(m))).toBe(true);
+  });
+
+  test("start() bypasses waitPortFree (initial boot / external restart)", async () => {
+    let called = 0;
+    const waitPortFree = () => { called += 1; return Promise.resolve(0); };
+    const { supervisor, procs } = makeSupervisor({ waitPortFree });
+
+    supervisor.start(false);
+    await drainMicrotasks();
+
+    expect(procs).toHaveLength(1);
+    expect(called).toBe(0);
   });
 });
 

--- a/packages/inference/router/src/mlx-supervisor.ts
+++ b/packages/inference/router/src/mlx-supervisor.ts
@@ -39,6 +39,13 @@ export interface SupervisorDeps {
   backoffSchedule?: number[];
   /** Give up after this many consecutive failed respawns. Defaults to 10. */
   maxConsecutiveFailures?: number;
+  /**
+   * Probe that resolves (with ms waited) when MLX's TCP port is free, or
+   * rejects on timeout. Called before each *respawn* (not before start()).
+   * If omitted, the supervisor spawns immediately after backoff — the
+   * pre-#38 behaviour, kept for tests that don't care about port races.
+   */
+  waitPortFree?: () => Promise<number>;
 }
 
 export interface SupervisorSnapshot {
@@ -52,6 +59,8 @@ export interface SupervisorSnapshot {
   consecutiveFailures: number;
   isHealthy: boolean;
   givenUp: boolean;
+  /** ms waited for port-free probe on the most recent respawn, or null. */
+  lastPortWaitMs: number | null;
 }
 
 const DEFAULT_BACKOFF = [1000, 2000, 4000, 8000, 16000, 30000];
@@ -65,6 +74,7 @@ export class MlxSupervisor {
   private readonly now: () => number;
   private readonly backoffSchedule: number[];
   private readonly maxFailures: number;
+  private readonly waitPortFree: (() => Promise<number>) | null;
 
   private currentProc: ProcLike | null = null;
   /** The proc whose exit we're expecting (shutdown, toggle). Reset on consumption. */
@@ -80,6 +90,7 @@ export class MlxSupervisor {
   private consecutiveFailures = 0;
   private isHealthy = false;
   private givenUp = false;
+  private lastPortWaitMs: number | null = null;
 
   constructor(deps: SupervisorDeps) {
     this.spawnFn = deps.spawn;
@@ -91,6 +102,7 @@ export class MlxSupervisor {
       ? [...deps.backoffSchedule]
       : [...DEFAULT_BACKOFF];
     this.maxFailures = deps.maxConsecutiveFailures ?? DEFAULT_MAX_FAILURES;
+    this.waitPortFree = deps.waitPortFree ?? null;
   }
 
   /**
@@ -158,6 +170,7 @@ export class MlxSupervisor {
       consecutiveFailures: this.consecutiveFailures,
       isHealthy: this.isHealthy,
       givenUp: this.givenUp,
+      lastPortWaitMs: this.lastPortWaitMs,
     };
   }
 
@@ -202,10 +215,41 @@ export class MlxSupervisor {
     this.respawnTimer = this.setTimeoutFn(() => {
       this.respawnTimer = null;
       if (this.givenUp) return;
+      this.respawnAfterPortFree(thinking);
+    }, delayMs);
+  }
+
+  /**
+   * Wait for the MLX port to be free, then spawn. If no probe is configured,
+   * spawn immediately (pre-#38 behaviour). If the probe rejects (timeout),
+   * log a warning and spawn anyway — we're already degraded, refusing to
+   * respawn would make things worse.
+   */
+  private respawnAfterPortFree(thinking: boolean): void {
+    const doSpawn = () => {
+      if (this.givenUp) return;
       this.respawnCount += 1;
       this.log(`respawning MLX: attempt #${this.respawnCount} thinking=${thinking}`);
       this.spawnChild(thinking);
-    }, delayMs);
+    };
+
+    if (!this.waitPortFree) {
+      doSpawn();
+      return;
+    }
+
+    this.waitPortFree().then(
+      (waitMs) => {
+        this.lastPortWaitMs = waitMs;
+        this.log(`port wait complete: ${waitMs}ms`);
+        doSpawn();
+      },
+      (err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        this.log(`port wait failed: ${msg}. spawning anyway (degraded).`);
+        doSpawn();
+      },
+    );
   }
 
   private cancelRespawnTimer(): void {

--- a/packages/inference/router/src/router.ts
+++ b/packages/inference/router/src/router.ts
@@ -11,6 +11,7 @@
  */
 
 import { spawnSync, spawn } from "node:child_process";
+import net from "node:net";
 import { loadRouterConfig, type LoadedRouterConfig } from "./config";
 import { MlxSupervisor } from "./mlx-supervisor";
 import type { ModelEntry, ChatMessage, ChatResponse, RoutingResult, JurorResult, JuryResult } from "./types";
@@ -115,6 +116,54 @@ function killMlxServers(): void {
   mlxState.pid = null;
 }
 
+/**
+ * TCP connect-probe: resolves (with ms waited) once the MLX port refuses
+ * connections, or rejects on timeout. Addresses issue #38 — the dying MLX
+ * child can hold :8080 briefly after pkill returns, racing the replacement
+ * child's bind() and producing EADDRINUSE log noise.
+ */
+function waitMlxPortFree(timeoutMs = 5000, intervalMs = 100): Promise<number> {
+  const [hostPart, portPart] = MLX_HOST.split(":");
+  const host = hostPart || "127.0.0.1";
+  const port = Number.parseInt(portPart ?? "8080", 10);
+  const start = Date.now();
+
+  return new Promise((resolve, reject) => {
+    const attempt = () => {
+      const socket = net.connect({ host, port });
+      let settled = false;
+      const cleanup = () => { settled = true; socket.removeAllListeners(); socket.destroy(); };
+
+      socket.setTimeout(200);
+      socket.once("connect", () => {
+        if (settled) return;
+        cleanup();
+        // Port still bound. Retry or give up.
+        if (Date.now() - start >= timeoutMs) {
+          reject(new Error(`port ${port} still bound after ${timeoutMs}ms`));
+          return;
+        }
+        setTimeout(attempt, intervalMs);
+      });
+      socket.once("error", () => {
+        if (settled) return;
+        cleanup();
+        resolve(Date.now() - start); // ECONNREFUSED — port free
+      });
+      socket.once("timeout", () => {
+        if (settled) return;
+        cleanup();
+        if (Date.now() - start >= timeoutMs) {
+          reject(new Error(`port ${port} probe timeout after ${timeoutMs}ms`));
+          return;
+        }
+        setTimeout(attempt, intervalMs);
+      });
+    };
+    attempt();
+  });
+}
+
 const mlxSupervisor = new MlxSupervisor({
   spawn: (thinking: boolean) => {
     const args = [
@@ -132,6 +181,7 @@ const mlxSupervisor = new MlxSupervisor({
     return proc;
   },
   log: (m) => console.log(`[mlx-sup] ${m}`),
+  waitPortFree: () => waitMlxPortFree(),
 });
 
 async function startMlxServer(thinking: boolean): Promise<void> {


### PR DESCRIPTION
## Summary

During intentional MLX restarts and unexpected exits, the dying child could hold `:8080` briefly after `pkill`/`SIGTERM` returned, racing the replacement for `bind()` and producing `OSError: [Errno 48] Address already in use` log noise.

The supervisor now exposes an optional `waitPortFree` probe that runs on the **respawn path** (after backoff, before `spawnChild`). `router.ts` wires in a TCP connect-probe that resolves when `:8080` refuses connections (5s cap, 100ms interval). If the probe rejects (timeout), the supervisor logs a warning and spawns anyway — refusing to respawn would only make a degraded state worse.

### Why connect-probe over SIGKILL + `kill -0`

Issue #38 suggested two options. I went with connect-probe:

- **Verifies the actual invariant we care about.** `kill -0` proves the process is gone; it doesn't prove the socket has been released. The race this fixes is specifically about port binding, so probe the port.
- **Doesn't require owning the child PID.** The supervisor is I/O-free by design and doesn't do the killing — `router.ts` does (`pkill`, `launchctl bootout`). A PID-poll would require threading the PID through or duplicating kill logic.
- **Preserves SIGTERM semantics.** SIGKILL would lose in-flight MLX cleanup (leaked semaphores already appear in the logs under SIGTERM — SIGKILL would make that worse) and still wouldn't guarantee immediate port release on macOS.

## Supervisor state diff

New field: `lastPortWaitMs: number | null` — ms waited for port-free probe on the most recent respawn, or null if no probe is configured or no respawn has happened yet. Surfaced via `/health` since `mlx.supervisor` already passes `getState()` through.

## TDD

Red → green → refactor:

1. Red: three tests in `mlx-supervisor.test.ts`:
   - respawn waits for probe resolution before spawning
   - probe rejection doesn't block respawn (degraded mode)
   - `start()` bypasses `waitPortFree` (initial boot path unchanged)
2. Green: added `respawnAfterPortFree()` helper; scheduleRespawn delegates to it.
3. Refactor: minimal — one new helper, one new field.

Full router suite: **35 pass / 0 fail** (17 supervisor unit + 2 E2E + 16 others).

## Live verification on ren3

**Before:** (from issue #38 — previously observed EADDRINUSE in router logs on pkill cycles)

**After** (this branch, deployed as fleet-router@1.1.1):

```
[mlx-sup] MLX exited unexpectedly: code=null signal=SIGTERM failures=1 next-backoff=1000ms
[mlx-sup] port wait complete: 26ms
[mlx-sup] respawning MLX: attempt #1 thinking=false
[mlx] starting server: thinking=false
[mlx-sup] spawned MLX: pid=1125 thinking=false
2026-04-05 14:10:07,061 - INFO - Starting httpd at 0.0.0.0 on port 8080...
[mlx-sup] healthy: respawns=1 isHealthy=true backoff reset
```

No `OSError: [Errno 48]` in the router log. `/health` post-recovery:

```json
{"pid":1125,"respawnCount":1,"consecutiveFailures":0,"isHealthy":true,"lastPortWaitMs":26}
```

## Version

Bumps `@seed/router` to **1.1.1**.

Closes #38