### PR TITLE
fix: expand CI matrix and standardize package.json fields

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,11 +21,16 @@ jobs:
       fail-fast: false
       matrix:
         package:
+          - packages/core
           - packages/fleet/control
-          - packages/memory
-          - packages/inference/router
-          - packages/providers
           - packages/hosts
+          - packages/inference/jury
+          - packages/inference/queue
+          - packages/inference/router
+          - packages/inference/sensitivity
+          - packages/inference/utils
+          - packages/memory
+          - packages/providers
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/bun.lock
+++ b/bun.lock
@@ -31,10 +31,10 @@
       "version": "0.1.0",
       "dependencies": {
         "@seed/core": "workspace:*",
-        "typescript": "^5.7.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
+        "typescript": "^5.7.0",
       },
     },
     "packages/inference/jury": {
@@ -68,10 +68,10 @@
         "@seed/inference-utils": "workspace:*",
         "@seed/jury": "workspace:*",
         "@seed/sensitivity": "workspace:*",
-        "typescript": "^5.7.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
+        "typescript": "^5.7.0",
       },
     },
     "packages/inference/sensitivity": {
@@ -102,11 +102,9 @@
     "packages/providers": {
       "name": "@seed/providers",
       "version": "0.2.0",
-      "dependencies": {
-        "typescript": "^5.7.0",
-      },
       "devDependencies": {
         "@types/bun": "latest",
+        "typescript": "^5.7.0",
       },
     },
   },

--- a/packages/fleet/control/package.json
+++ b/packages/fleet/control/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@seed/fleet-control",
   "version": "0.6.0",
+  "private": true,
   "type": "module",
   "scripts": {
     "server": "bun run src/main.ts",

--- a/packages/fleet/topology/package.json
+++ b/packages/fleet/topology/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@seed/fleet-topology",
   "version": "0.1.0",
+  "private": true,
   "description": "Static (file-drop) workload that deposits seed.config.json on a fleet machine. Decouples fleet topology from router release cadence.",
   "type": "module",
   "scripts": {

--- a/packages/hosts/package.json
+++ b/packages/hosts/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@seed/hosts",
   "version": "0.1.0",
+  "private": true,
   "type": "module",
   "scripts": {
     "build": "tsc",
@@ -9,10 +10,10 @@
     "run-headless": "bun run src/run-headless.ts"
   },
   "dependencies": {
-    "@seed/core": "workspace:*",
-    "typescript": "^5.7.0"
+    "@seed/core": "workspace:*"
   },
   "devDependencies": {
-    "@types/bun": "latest"
+    "@types/bun": "latest",
+    "typescript": "^5.7.0"
   }
 }

--- a/packages/inference/jury/package.json
+++ b/packages/inference/jury/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@seed/jury",
   "version": "0.2.0",
+  "private": true,
   "type": "module",
   "scripts": {
     "test": "bun test",

--- a/packages/inference/queue/package.json
+++ b/packages/inference/queue/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@seed/queue",
   "version": "0.1.0",
+  "private": true,
   "type": "module",
   "scripts": {
     "server": "bun run src/main.ts",

--- a/packages/inference/router/package.json
+++ b/packages/inference/router/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@seed/router",
   "version": "1.3.0",
+  "private": true,
   "description": "Rule-based fleet router backed by mlx-vlm, with deterministic keyword routing and jury mode",
   "type": "module",
   "scripts": {
@@ -13,10 +14,10 @@
     "@seed/core": "workspace:*",
     "@seed/inference-utils": "workspace:*",
     "@seed/jury": "workspace:*",
-    "@seed/sensitivity": "workspace:*",
-    "typescript": "^5.7.0"
+    "@seed/sensitivity": "workspace:*"
   },
   "devDependencies": {
-    "@types/bun": "latest"
+    "@types/bun": "latest",
+    "typescript": "^5.7.0"
   }
 }

--- a/packages/inference/sensitivity/package.json
+++ b/packages/inference/sensitivity/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@seed/sensitivity",
   "version": "0.1.0",
+  "private": true,
   "type": "module",
   "scripts": {
     "test": "bun test",

--- a/packages/inference/utils/package.json
+++ b/packages/inference/utils/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@seed/inference-utils",
   "version": "0.1.0",
+  "private": true,
   "type": "module",
   "scripts": {
     "test": "bun test",

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@seed/memory",
   "version": "0.4.10",
+  "private": true,
   "type": "module",
   "scripts": {
     "server": "bun run src/main.ts",

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@seed/providers",
   "version": "0.2.0",
+  "private": true,
   "type": "module",
   "scripts": {
     "build": "tsc",
@@ -8,10 +9,8 @@
     "test": "bun test",
     "typecheck": "bunx tsc --noEmit"
   },
-  "dependencies": {
-    "typescript": "^5.7.0"
-  },
   "devDependencies": {
-    "@types/bun": "latest"
+    "@types/bun": "latest",
+    "typescript": "^5.7.0"
   }
 }


### PR DESCRIPTION
## Summary

- Add 5 missing packages to CI test matrix: `core`, `inference/jury`, `inference/queue`, `inference/sensitivity`, `inference/utils`
- Add `private: true` to all 10 workspace packages that were missing it
- Move `typescript` from `dependencies` to `devDependencies` in `hosts`, `providers`, and `inference/router`

All 5 new matrix packages pass tests and typecheck locally. The `packages/skills/` tests remain handled by the existing `skills-drift` job.

## Test plan

- [ ] CI passes for all 10 matrix entries (5 existing + 5 new)
- [ ] `skills-drift` job still passes
- [ ] `bun install` resolves without errors after dependency moves